### PR TITLE
Leva server-side components, Clerk and Portal support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [unreleased]
 
+- #29:
+
+  - Upgrades viewer dependencies (other than MathBox) to versions compatible
+    with Portal and able to be evaluated via SCI
+
 - #26:
 
   - Adds `emmy.clerk` with support for configuring Clerk projects and specific

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@
   - Upgrades viewer dependencies (other than MathBox) to versions compatible
     with Portal and able to be evaluated via SCI
 
+  - Adds `emmy.leva`, with functions for creating Reagent fragments that
+    configure the components from [Leva.cljs](https://leva.mentat.org/) for
+    Portal or Clerk
+
+  - `dev/emmy_viewers/leva.clj` shows off some basic demos, though these are not
+    yet organized
+
+  - `emmy.viewer/fragment` now tags its inputs as Reagent components, vs the
+    accidental `mafs`-specific tagging that existed before. `mafs` components
+    receive correct metadata to render with or without styling.
+
+  - `emmy/portal/leva.cljs` gives Portal the ability to render Leva components
+    by loading Leva into portal's SCI context.
+
 - #26:
 
   - Adds `emmy.clerk` with support for configuring Clerk projects and specific

--- a/deps.edn
+++ b/deps.edn
@@ -28,9 +28,7 @@
   :portal
   {:extra-paths ["dev"]
    :extra-deps
-   {djblue/portal
-    {:local/root "../portal"}
-    #_{:mvn/version "0.42.0"}}}
+   {djblue/portal {:mvn/version "0.42.0"}}}
 
   :build
   {:deps

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,9 @@
  {org.clojure/data.json {:mvn/version "2.4.0"}
   org.mentat/emmy {:mvn/version "0.30.0"}
   org.mentat/jsxgraph.cljs {:mvn/version "0.2.0"}
-  org.mentat/leva.cljs {:local/root "../leva.cljs" #_#_:mvn/version "0.2.2"}
+  org.mentat/leva.cljs
+  {:git/url "https://github.com/mentat-collective/Leva.cljs.git"
+   :git/sha "7254c16add250cded6b0c641bf3e0540e5399299"}
   org.mentat/mathbox.cljs {:mvn/version "0.2.0"}
   org.mentat/mathlive.cljs {:mvn/version "0.2.0"}
   org.mentat/mafs.cljs {:mvn/version "0.3.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
  {org.clojure/data.json {:mvn/version "2.4.0"}
   org.mentat/emmy {:mvn/version "0.30.0"}
   org.mentat/jsxgraph.cljs {:mvn/version "0.2.0"}
-  org.mentat/leva.cljs {:mvn/version "0.2.2"}
+  org.mentat/leva.cljs {:local/root "../leva.cljs" #_#_:mvn/version "0.2.2"}
   org.mentat/mathbox.cljs {:mvn/version "0.2.0"}
   org.mentat/mathlive.cljs {:mvn/version "0.2.0"}
   org.mentat/mafs.cljs {:mvn/version "0.3.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,11 @@
 {:paths ["src" "resources"]
  :deps
  {org.clojure/data.json {:mvn/version "2.4.0"}
-  org.mentat/emmy {:mvn/version "0.30.0"}
-  org.mentat/jsxgraph.cljs {:mvn/version "0.2.0"}
-  org.mentat/leva.cljs
-  {:git/url "https://github.com/mentat-collective/Leva.cljs.git"
-   :git/sha "7254c16add250cded6b0c641bf3e0540e5399299"}
+  org.mentat/emmy {:mvn/version "0.31.0"}
+  org.mentat/jsxgraph.cljs {:mvn/version "0.2.1"}
+  org.mentat/leva.cljs {:mvn/version "0.3.0"}
   org.mentat/mathbox.cljs {:mvn/version "0.2.0"}
-  org.mentat/mathlive.cljs {:mvn/version "0.2.0"}
+  org.mentat/mathlive.cljs {:mvn/version "0.2.1"}
   org.mentat/mafs.cljs {:mvn/version "0.3.0"}
   org.mentat/clerk-utils {:mvn/version "0.6.0"}}
 
@@ -30,7 +28,9 @@
   :portal
   {:extra-paths ["dev"]
    :extra-deps
-   {djblue/portal {:mvn/version "0.42.0"}}}
+   {djblue/portal
+    {:local/root "../portal"}
+    #_{:mvn/version "0.42.0"}}}
 
   :build
   {:deps

--- a/dev/emmy_viewers/leva.clj
+++ b/dev/emmy_viewers/leva.clj
@@ -14,12 +14,52 @@
 
 ;; This control panel is summoned into existence by this server-side value:
 
-(ev/with-let [!synced {:number 10
-                       :color {:r 10 :g 12 :b 4}
-                       :string "Hi!"
-                       :point {:x 1 :y 1}}]
+(ev/with-let
+  [!synced {:number 10
+            :color {:r 10 :g 12 :b 4}
+            :string "Hi!"
+            :point {:x 1 :y 1}}]
   [:<>
    (ec/inspect-state !synced)
    (leva/controls
     {:folder {:name "Quickstart!"}
      :atom !synced})])
+
+;; Here are some examples of sub-schema:
+
+(ev/fragment
+ [:div {:style {:width "60%" :margin "auto"}}
+  (leva/sub-panel
+   {:fill true :titleBar {:drag false}}
+   (leva/controls
+    {:schema
+     {:group
+      (leva/button-group
+       "Meal Choice"
+       {"Meat" '#(js/alert "Meat!")
+        "Potatoes" '#(js/alert "Potatoes!")
+        "Cabbage" '#(js/alert "Cabbage!")})}}))])
+
+(ev/with-let [!local {:number 7}]
+  [:div {:style {:width "60%" :margin "auto"}}
+   (leva/sub-panel
+    {:fill true :titleBar {:drag false}}
+    (leva/controls
+     {:folder {:name "Outer Folder"}
+      :atom !local
+      :schema
+      {:number {:order -1}
+       "Yellow Subfolder"
+       (leva/folder
+        {:button (leva/button
+                  '(fn []
+                     (js/alert
+                      "Button pressed!")))
+         :group  (leva/button-group
+                  {"1px" '#(js/alert "1px")
+                   "2px" '#(js/alert "2px")})
+         "Number Monitor" (leva/monitor
+                           `(fn [] ~(ev/get !local :number))
+                           {:graph true
+                            :interval 30})}
+        {:color "yellow"})}}))])

--- a/dev/emmy_viewers/leva.clj
+++ b/dev/emmy_viewers/leva.clj
@@ -1,0 +1,25 @@
+^{:nextjournal.clerk/visibility {:code :hide}}
+(ns emmy-viewers.leva
+  #:nextjournal.clerk
+  {:toc true :no-cache true}
+  (:require [emmy.clerk :as ec]
+            [emmy.leva :as leva]
+            [emmy.viewer :as ev]
+            [nextjournal.clerk :as-alias clerk]))
+
+;; # Leva Demo
+
+^{::clerk/visibility {:code :hide :result :hide}}
+(ec/install!)
+
+;; This control panel is summoned into existence by this server-side value:
+
+(ev/with-let [!synced {:number 10
+                       :color {:r 10 :g 12 :b 4}
+                       :string "Hi!"
+                       :point {:x 1 :y 1}}]
+  [:<>
+   (ec/inspect-state !synced)
+   (leva/controls
+    {:folder {:name "Quickstart!"}
+     :atom !synced})])

--- a/dev/examples/mafs.clj
+++ b/dev/examples/mafs.clj
@@ -98,16 +98,16 @@
 ;; Build up a more complex set of fragments with a combinators:
 
 (defn chain [& points]
-  (-> (first
-       (reduce (fn [[acc tail] p]
-                 (let [tip (mapv + tail p)
-                       v   (mafs/vector
-                            {:tail tail :tip tip})]
-                   [(conj acc v) tip]))
-               [[:<>] [0 0]]
-               points))
-      (ev/fragment
-       #(mafs/mafs (mafs/cartesian) %))))
+  (mafs/mafs
+   (mafs/cartesian)
+   (first
+    (reduce (fn [[acc tail] p]
+              (let [tip (mapv + tail p)
+                    v   (mafs/vector
+                         {:tail tail :tip tip})]
+                [(conj acc v) tip]))
+            [[:<>] [0 0]]
+            points))))
 
 ;; apply it:
 

--- a/dev/examples/portal.clj
+++ b/dev/examples/portal.clj
@@ -18,20 +18,18 @@
      {:emmy.portal/tex {:macros {"\\f" "#1f(#2)"}}
       :theme :portal.colors/zenburn}))
 
-  (tap> (mafs/of-x sin))
-
   (tap>
-   (ev/with-let [!phase [0 0]]
-     (let [shifted (ev/with-params {:atom !phase :params [0]}
-                     (fn [shift]
-                       (((cube D) tanh) (- identity shift))))]
-       (mafs/mafs
-        (mafs/cartesian)
-        (mafs/of-x shifted)
-        (mafs/inequality
-         {:y {:<= shifted :> cos} :color :blue})
-        (mafs/movable-point
-         {:atom !phase :constrain "horizontal"})))))
+   (emmy.mafs.core/mafs-meta
+    (ev/with-let [!phase [0 0]]
+      (let [shifted (ev/with-params {:atom !phase :params [0]}
+                      (fn [shift]
+                        (((cube D) tanh) (- identity shift))))]
+        (mafs/mafs
+         (mafs/cartesian)
+         (mafs/of-x shifted)
+         (mafs/inequality
+          {:y {:<= shifted :> cos} :color :blue})
+         (mafs/movable-point {:atom !phase :constrain "horizontal"}))))))
 
   (tap> (mafs/of-x sin {:color :indigo}))
 
@@ -43,7 +41,7 @@
                           :string "Hi!"
                           :point {:x 1 :y 1}}]
      [:<>
-      [:pre (pr-str !synced)]
+      [:pre `(pr-str @~!synced)]
       (leva/controls
        {:folder {:name "Quickstart!"}
         :atom !synced})]))

--- a/dev/examples/portal.clj
+++ b/dev/examples/portal.clj
@@ -4,6 +4,7 @@
              infinite? abs ref partial =])
   (:require [emmy.mafs.core]
             [emmy.env :as e :refer :all]
+            [emmy.leva :as leva]
             [emmy.mafs :as mafs]
             [emmy.portal :as p]
             [emmy.viewer :as ev]
@@ -33,6 +34,21 @@
          {:atom !phase :constrain "horizontal"})))))
 
   (tap> (mafs/of-x sin {:color :indigo}))
+
+  ;; ## Leva
+
+  (tap>
+   (ev/with-let [!synced {:number 10
+                          :color {:r 10 :g 12 :b 4}
+                          :string "Hi!"
+                          :point {:x 1 :y 1}}]
+     [:<>
+      [:pre (pr-str !synced)]
+      (leva/controls
+       {:folder {:name "Quickstart!"}
+        :atom !synced})]))
+
+  ;; ## Expressions / TeX
 
   (tap>
    (with-meta

--- a/src/emmy/leva.clj
+++ b/src/emmy/leva.clj
@@ -1,13 +1,15 @@
 (ns emmy.leva
+  "Server-side rendering functions for the components declared in the
+  [`leva.core`](https://cljdoc.org/d/org.mentat/leva.cljs/CURRENT/api/leva.core)
+  namespace of the [`Leva.cljs` project](https://leva.mentat.org)."
   (:require [emmy.viewer :as ev]))
-
-;; TODO update docstrings for special components, get examples in
 
 ;; ## Special Inputs
 
 (defn button
-  "Returns a schema entry that defines a button, given a function `on-click` and a
-  map `opt` of options.
+  "Given a quoted ClojureScript function `on-click` and a map `opt` of options,
+  returns a client-side fragment that generates a schema entry defining a
+  button.
 
   The `opts` allowed are any found in the types
 
@@ -22,28 +24,30 @@
    (list 'leva.core/button on-click opts)))
 
 (defn button-group
-  "Returns a schema entry that defines a button group, given either
+  "Returns a client-side fragment that generates a schema entry defining a button group,
+  given either
 
-  - a label and a map of `{<string> (fn [get] ,,,)}`
+  - a label and a map of `{<string> '(fn [get] ,,,)}` where the `fn` is a quoted
+    ClojureScript function
   - only the map
 
   Where `get` is of type `string => value`, and allows you to query the internal
   leva store.
 
   Feel free to ignore `get` and query the stateful atom associated with
-  this [[Controls]] instance from the value function."
+  this [[controls]] instance from the value function."
   ([opts]
    (list 'leva.core/button-group opts))
   ([label opts]
    (list 'leva.core/button-group label opts)))
 
 (defn monitor
-  "Returns a schema entry that defines a \"monitor\", given as a first argument
-  either
+  "Returns a client-side fragment that generates a schema entry defining a
+  \"monitor\", given as a first argument either
 
-  - a no-arg function that returns a number, or
-  - a react `MutableRefObject` returned by `useRef`, where `(.-current ref)`
-    returns a number
+  - a no-arg (quoted ClojureScript) function that returns a number, or
+  - a symol referencing a react `MutableRefObject` returned by `useRef`,
+    where `(.-current ref)` returns a number
 
   and an optional settings map as a second argument. The supported (optional)
   settings are
@@ -60,23 +64,24 @@
 
 (defn folder
   "Given a sub-schema `schema` and an optional map of folder `settings`, returns a
-  schema entry that wraps `schema` in a subfolder.
+  client-side fragment that generates a schema entry wrapping `schema` in a
+  subfolder.
 
   The supported (optional) settings are
 
-  - `:collapsed` if true, the folder will be collapsed on initial render.
+  - `:collapsed`: if true, the folder will be collapsed on initial render.
     Defaults to false.
 
-  - `:render` (fn [get] <boolean>), providing dynamic control or whether or not
-    the folder appears.
+  - `:render`: quoted ClojureScript function of hte form `(fn [get] <boolean>)`,
+    providing dynamic control or whether or not the folder appears.
 
       `get` is of type `string => value`, and allows you to query the internal
       leva store. If the `:render` fn returns true, this folder will be rendered in
       the panel; if false it won't render.
 
-  - `:color` color string, sets the color of the folder title.
+  - `:color`: color string, sets the color of the folder title.
 
-  - `:order` number, sets the order of this folder relative to other components
+  - `:order`: number, sets the order of this folder relative to other components
     at the same level."
   ([schema]
    (list 'leva.core/folder schema))
@@ -85,14 +90,68 @@
 
 ;; ## Components
 
-(defn config [opts & children]
+(defn config
+  "Returns a fragment that configures a Leva panel with the supplied map of `opts`
+  without explicitly rendering any inputs into it.
+
+  If `:store` is not provided, configures the globally available Leva panel.
+
+  See the
+  type [`LevaRootProps`](https://github.com/pmndrs/leva/blob/main/packages/leva/src/components/Leva/LevaRoot.tsx#L13-L93)
+  for a full list of available entries for `opts` and documentation for each.
+
+  You can pass any number of `children` components if you like for
+  organizational purposes.
+
+  If you pass `:store`, any [[controls]] component in `children` will use that
+  store vs the store of the global panel.
+
+  NOTE: We recommend using [[sub-panel]] to declare non-global Leva panels,
+  rather than worrying about creating and passing your own Leva store via
+  `:store`. But for advanced use cases, please feel free!"
+  [opts & children]
   (ev/fragment
    (into ['leva.core/Config opts] children)))
 
-(defn subpanel [opts & children]
-  (ev/fragment
-   (into ['leva.core/Subpanel opts] children)))
+(defn sub-panel
+  "Returns a fragment that will configure a non-global, standalone Leva panel with
+  the supplied map of `opts`.
 
-(defn controls [opts]
+  Any instance of [[controls]] passed as `children` will render into this
+  subpanel and not touch the global store.
+
+  See the
+  type [`LevaRootProps`](https://github.com/pmndrs/leva/blob/main/packages/leva/src/components/Leva/LevaRoot.tsx#L13-L93)
+  for a full list of available entries for `opts` and documentation for each."
+  [opts & children]
+  (ev/fragment
+   (into ['leva.core/SubPanel opts] children)))
+
+(defn controls
+  "Returns a fragment that will render inputs into a global or local Leva control
+  panel, possibly synchronizing the panel's state into a provided atom.
+
+  Placing this component anywhere in the render tree will add controls to the
+  global Leva panel.
+
+  To modify a local Leva panel, nest this component inside of a [[sub-panel]].
+
+  Supported `opts` are:
+
+  - `:schema`: A leva schema definition. Any value _not_ present in the supplied
+    `:atom` should provide an `:onChange` handler.
+
+  - `:atom`: symbol referencing an atom of key => initial value for schema
+    entries. Any entry found in both `:atom` and in `:schema` will remain
+    synchronized between the panel and the supplied `:atom`.
+
+  - `:folder`: optional map with optional keys `:name` and `:settings`:
+
+    - `:name`: if provided, these controls will be nested inside of a folder
+      with this name.
+
+    - `:settings`: optional map customizing the folder's settings.
+      See [[folder]] for a description of the supported options."
+  [opts]
   (ev/fragment
    ['leva.core/Controls opts]))

--- a/src/emmy/leva.clj
+++ b/src/emmy/leva.clj
@@ -1,8 +1,89 @@
 (ns emmy.leva
-  "TODO this should probably live in `emmy.leva`, no core needed."
   (:require [emmy.viewer :as ev]))
 
-;; TODO get the various special input components defined.
+;; TODO update docstrings for special components, get examples in
+
+;; ## Special Inputs
+
+(defn button
+  "Returns a schema entry that defines a button, given a function `on-click` and a
+  map `opt` of options.
+
+  The `opts` allowed are any found in the types
+
+  - [`ButtonSettings`](https://github.com/pmndrs/leva/blob/33b2d9948818c5828409e3cf65baed4c7492276a/packages/leva/src/types/public.ts#L47)
+  - [`GenericSchemaItemOptions`](https://github.com/pmndrs/leva/blob/33b2d9948818c5828409e3cf65baed4c7492276a/packages/leva/src/types/public.ts#L144-L149)
+
+  In [public.ts](https://github.com/pmndrs/leva/blob/33b2d9948818c5828409e3cf65baed4c7492276a/packages/leva/src/types/public.ts)
+  in [Leva's repository](https://github.com/pmndrs/leva). "
+  ([on-click]
+   (button on-click {}))
+  ([on-click opts]
+   (list 'leva.core/button on-click opts)))
+
+(defn button-group
+  "Returns a schema entry that defines a button group, given either
+
+  - a label and a map of `{<string> (fn [get] ,,,)}`
+  - only the map
+
+  Where `get` is of type `string => value`, and allows you to query the internal
+  leva store.
+
+  Feel free to ignore `get` and query the stateful atom associated with
+  this [[Controls]] instance from the value function."
+  ([opts]
+   (list 'leva.core/button-group opts))
+  ([label opts]
+   (list 'leva.core/button-group label opts)))
+
+(defn monitor
+  "Returns a schema entry that defines a \"monitor\", given as a first argument
+  either
+
+  - a no-arg function that returns a number, or
+  - a react `MutableRefObject` returned by `useRef`, where `(.-current ref)`
+    returns a number
+
+  and an optional settings map as a second argument. The supported (optional)
+  settings are
+
+  - `:graph`: if true, the returned monitor shows a graph. if false, the monitor
+    displays a number.
+
+  - `:interval`: the number of milliseconds to wait between queries of
+    `object-or-fn`."
+  ([object-or-fn]
+   (list 'leva.core/monitor object-or-fn))
+  ([object-or-fn settings]
+   (list 'leva.core/monitor object-or-fn settings)))
+
+(defn folder
+  "Given a sub-schema `schema` and an optional map of folder `settings`, returns a
+  schema entry that wraps `schema` in a subfolder.
+
+  The supported (optional) settings are
+
+  - `:collapsed` if true, the folder will be collapsed on initial render.
+    Defaults to false.
+
+  - `:render` (fn [get] <boolean>), providing dynamic control or whether or not
+    the folder appears.
+
+      `get` is of type `string => value`, and allows you to query the internal
+      leva store. If the `:render` fn returns true, this folder will be rendered in
+      the panel; if false it won't render.
+
+  - `:color` color string, sets the color of the folder title.
+
+  - `:order` number, sets the order of this folder relative to other components
+    at the same level."
+  ([schema]
+   (list 'leva.core/folder schema))
+  ([schema settings]
+   (list 'leva.core/folder schema settings)))
+
+;; ## Components
 
 (defn config [opts & children]
   (ev/fragment

--- a/src/emmy/leva.clj
+++ b/src/emmy/leva.clj
@@ -1,0 +1,17 @@
+(ns emmy.leva
+  "TODO this should probably live in `emmy.leva`, no core needed."
+  (:require [emmy.viewer :as ev]))
+
+;; TODO get the various special input components defined.
+
+(defn config [opts & children]
+  (ev/fragment
+   (into ['leva.core/Config opts] children)))
+
+(defn subpanel [opts & children]
+  (ev/fragment
+   (into ['leva.core/Subpanel opts] children)))
+
+(defn controls [opts]
+  (ev/fragment
+   ['leva.core/Controls opts]))

--- a/src/emmy/mafs/coordinates.clj
+++ b/src/emmy/mafs/coordinates.clj
@@ -32,7 +32,7 @@
       line, or [[mafs.core/labelPi]]. "
   ([] (cartesian {}))
   ([opts]
-   (ev/fragment
+   (mafs/fragment
     ['mafs.coordinates/Cartesian opts]
     mafs/mafs)))
 
@@ -59,6 +59,6 @@
       line, or [[mafs.core/labelPi]]. "
   ([] (polar {}))
   ([opts]
-   (ev/fragment
+   (mafs/fragment
     ['mafs.coordinates/Polar opts]
     mafs/mafs)))

--- a/src/emmy/mafs/coordinates.clj
+++ b/src/emmy/mafs/coordinates.clj
@@ -2,8 +2,7 @@
   "Server-side rendering functions for the components declared in the
   [`mafs.coordinates`](https://cljdoc.org/d/org.mentat/mafs.cljs/CURRENT/api/mafs.coordinates)
   namespace of the [`Mafs.cljs` project](https://mafs.mentat.org)."
-  (:require [emmy.viewer :as ev]
-            [emmy.mafs.core :as mafs]))
+  (:require [emmy.mafs.core :as mafs]))
 
 (defn cartesian
   "Takes an (optional) options map `opts` and returns a fragment that will render

--- a/src/emmy/mafs/core.clj
+++ b/src/emmy/mafs/core.clj
@@ -7,23 +7,31 @@
 
 ;; ## Viewer Machinery
 
+(defn mafs-meta [v]
+  (vary-meta v assoc
+             :portal.viewer/mafs? true
+             :portal.viewer/default :emmy.portal/mafs))
+
 (defn ^:no-doc default-viewer
   "Given a Reagent fragment for some standalone Mafs component, returns a version
   wrapped in `[mafs.core/Mafs [mafs.coordinates/Cartesian] ...]`, allowing it to
   render standalone."
   [child]
-  (ev/fragment
-   ['mafs.core/Mafs
-    ['mafs.coordinates/Cartesian]
-    child]))
+  (mafs-meta
+   (ev/fragment
+    ['mafs.core/Mafs
+     ['mafs.coordinates/Cartesian]
+     child])))
 
 (defn ^:no-doc fragment
   "Mafs-specific version of [[emmy.viewer/fragment]] that
   supplies [[default-viewer]] as the default, instead
   of [[emmy.viewer/reagent-viewer]]."
-  ([v] (ev/fragment v default-viewer))
+  ([v]
+   (fragment v default-viewer))
   ([v viewer]
-   (ev/fragment v viewer)))
+   (mafs-meta
+    (ev/fragment v viewer))))
 
 ;; ## Core Components
 
@@ -61,8 +69,9 @@
   - `:on-click`: Quoted ClojureScript `'(fn [point, mouse-event] ...)`, called
       when the view is clicked on, and passed the point where it was clicked."
   [& children]
-  (ev/fragment
-   (into ['mafs.core/Mafs] children)))
+  (mafs-meta
+   (ev/fragment
+    (into ['mafs.core/Mafs] children))))
 
 (defn point
   "Takes either

--- a/src/emmy/portal.clj
+++ b/src/emmy/portal.clj
@@ -12,7 +12,8 @@
   via [[portal.api/eval-str]]."
   ["emmy/portal/tex.cljs"
    "emmy/portal/reagent.cljs"
-   "emmy/portal/mafs.cljs"])
+   "emmy/portal/mafs.cljs"
+   #_"emmy/portal/leva.cljs"])
 
 (defn prepare!
   "Installs any npm dependencies specified by a `deps.cljs` file in some

--- a/src/emmy/portal.clj
+++ b/src/emmy/portal.clj
@@ -13,7 +13,7 @@
   ["emmy/portal/tex.cljs"
    "emmy/portal/reagent.cljs"
    "emmy/portal/mafs.cljs"
-   #_"emmy/portal/leva.cljs"])
+   "emmy/portal/leva.cljs"])
 
 (defn prepare!
   "Installs any npm dependencies specified by a `deps.cljs` file in some

--- a/src/emmy/portal/leva.cljs
+++ b/src/emmy/portal/leva.cljs
@@ -22,9 +22,6 @@
   The viewer is automatically installed by the functions in [[emmy.portal]]."
   (:require [emmy.viewer.css :refer [css-map]]
             [emmy.portal.css :as css]
-            #_["shadergraph" :as box]
-            ["leva"]
-            [leva.core]
-            #_[leva.core]))
+            [leva.core]))
 
 (apply css/inject! (:leva css-map))

--- a/src/emmy/portal/leva.cljs
+++ b/src/emmy/portal/leva.cljs
@@ -7,7 +7,7 @@
   Generate these fragments using the code in the [[emmy.mafs]] namespace and
   sub-namespaces.
 
-  To use this viewer, first install the `mafs` npm package:
+  To use this viewer, first install the `leva` npm package:
 
   ```bash
   npm install leva@0.9.34
@@ -20,8 +20,4 @@
   ```
 
   The viewer is automatically installed by the functions in [[emmy.portal]]."
-  (:require [emmy.viewer.css :refer [css-map]]
-            [emmy.portal.css :as css]
-            [leva.core]))
-
-(apply css/inject! (:leva css-map))
+  (:require [leva.core]))

--- a/src/emmy/portal/leva.cljs
+++ b/src/emmy/portal/leva.cljs
@@ -1,0 +1,30 @@
+(ns emmy.portal.leva
+  "Portal viewer for rendering Leva.cljs reagent snippets. Requiring this viewer
+  has the side-effect of requiring all namespaces
+  from [Mafs.cljs](https://github.com/mentat-collective/Leva.cljs) into the SCI
+  context.
+
+  Generate these fragments using the code in the [[emmy.mafs]] namespace and
+  sub-namespaces.
+
+  To use this viewer, first install the `mafs` npm package:
+
+  ```bash
+  npm install leva@0.9.34
+  ```
+
+  Then install the viewer:
+
+  ```clojure
+  (emmy.portal/install! \"emmy/portal/leva.cljs\")
+  ```
+
+  The viewer is automatically installed by the functions in [[emmy.portal]]."
+  (:require [emmy.viewer.css :refer [css-map]]
+            [emmy.portal.css :as css]
+            #_["shadergraph" :as box]
+            ["leva"]
+            [leva.core]
+            #_[leva.core]))
+
+(apply css/inject! (:leva css-map))

--- a/src/emmy/portal/mafs.cljs
+++ b/src/emmy/portal/mafs.cljs
@@ -36,7 +36,6 @@
             [portal.ui.theme :as theme]))
 
 (apply css/inject! (:mafs css-map))
-(apply css/inject! (:jsxgraph css-map))
 
 (def viewer-name :emmy.portal/mafs)
 

--- a/src/emmy/portal/mafs.cljs
+++ b/src/emmy/portal/mafs.cljs
@@ -36,6 +36,7 @@
             [portal.ui.theme :as theme]))
 
 (apply css/inject! (:mafs css-map))
+(apply css/inject! (:jsxgraph css-map))
 
 (def viewer-name :emmy.portal/mafs)
 
@@ -55,8 +56,9 @@
 (defn- ->style [theme]
   (let [lines (reduce-kv
                (fn [out mafs portal]
-                 (when-let [v (get theme portal)]
-                   (conj out (str "--mafs-" (name mafs) ": " v))))
+                 (if-let [v (get theme portal)]
+                   (conj out (str "--mafs-" (name mafs) ": " v))
+                   out))
                []
                theme-mapping)]
     (str
@@ -84,5 +86,6 @@
   (fn [v]
     (when-let [m (meta v)]
       (or (:portal.viewer/mafs? m)
+          (:portal.viewer/reagent? m)
           (= viewer-name
              (:portal.viewer/default m)))))})

--- a/src/emmy/portal/reagent.cljs
+++ b/src/emmy/portal/reagent.cljs
@@ -66,12 +66,13 @@
       [(->f v)]
       [:f> expand v])))
 
+(defn reagent? [v]
+  (when-let [m (meta v)]
+    (or (:portal.viewer/reagent? m)
+        (= viewer-name
+           (:portal.viewer/default m)))))
+
 (p/register-viewer!
  {:name viewer-name
   :component show-reagent
-  :predicate
-  (fn [v]
-    (when-let [m (meta v)]
-      (or (:portal.viewer/reagent? m)
-          (= viewer-name
-             (:portal.viewer/default m)))))})
+  :predicate reagent?})

--- a/src/emmy/viewer.clj
+++ b/src/emmy/viewer.clj
@@ -55,8 +55,8 @@
   ([v viewer-or-xform]
    (let [viewer (or viewer-or-xform reagent-viewer)]
      (vary-meta v assoc
-                :portal.viewer/mafs? true
-                :portal.viewer/default :emmy.portal/mafs
+                :portal.viewer/reagent? true
+                :portal.viewer/default :emmy.portal/reagent
                 ::clerk/viewer viewer))))
 
 ;; ## State Utilities


### PR DESCRIPTION
- #29:

  - Upgrades viewer dependencies (other than MathBox) to versions compatible
    with Portal and able to be evaluated via SCI

  - Adds `emmy.leva`, with functions for creating Reagent fragments that
    configure the components from [Leva.cljs](https://leva.mentat.org/) for
    Portal or Clerk

  - `dev/emmy_viewers/leva.clj` shows off some basic demos, though these are not
    yet organized

  - `emmy.viewer/fragment` now tags its inputs as Reagent components, vs the
    accidental `mafs`-specific tagging that existed before. `mafs` components
    receive correct metadata to render with or without styling.

  - `emmy/portal/leva.cljs` gives Portal the ability to render Leva components
    by loading Leva into portal's SCI context.