### PR TITLE
JSXGraph server-side components, Clerk and Portal support

### DIFF
--- a/dev/emmy_viewers/jsxgraph.clj
+++ b/dev/emmy_viewers/jsxgraph.clj
@@ -3,7 +3,7 @@
   #:nextjournal.clerk
   {:toc true :no-cache true}
   (:require [emmy.clerk :as ec]
-            #_#_[emmy.jsxgraph :as jsx]
+            [emmy.jsxgraph :as jsx]
             [emmy.viewer :as ev]
             [nextjournal.clerk :as-alias clerk]))
 
@@ -11,3 +11,216 @@
 
 ^{::clerk/visibility {:code :hide :result :hide}}
 (ec/install!)
+
+
+(ev/with-let [!state {:circumcenter true
+                      :orthocenter true
+                      :centroid true}]
+  (let [centroid? `(fn [] ~(ev/get !state :centroid))
+        orthocenter? `(fn [] ~(ev/get !state :orthocenter))
+        circumcenter? `(fn [] ~(ev/get !state :circumcenter))
+        cerise {:strokeColor "#901B77"
+                :fillColor "#CA147A"}
+        grass {:strokeColor "#009256"
+               :fillColor "#65B72E"
+               :visible true
+               :withLabel true}
+        perpendicular {:strokeColor "black"
+                       :visible orthocenter?
+                       :dash 1
+                       :strokeWidth 1}
+        median {:strokeWidth 1
+                :strokeColor "#333333"
+                :dash 2}]
+
+    (jsx/jsxgraph
+     {:boundingbox [-1.5 2 1.5 -1]
+      :showCopyright false
+      :keepaspectratio true}
+     (jsx/checkbox {:parents [-2 1.5 "Circumcenter"]
+                    :checked (ev/get !state :circumcenter)
+                    :on {:up `#(swap! ~!state assoc :circumcenter (not (.Value %)))}})
+     (jsx/checkbox {:parents [-2 1.3 "Orthocenter"]
+                    :checked (ev/get !state :orthocenter)
+                    :on {:up `#(swap! ~!state assoc :orthocenter (not (.Value %)))}})
+     (jsx/checkbox {:parents [-2 1.1 "Centroid"]
+                    :checked (ev/get !state :centroid)
+                    :on {:up `#(swap! ~!state assoc :centroid (not (.Value %)))}})
+
+     ;; Triangle
+     (jsx/point (assoc cerise :parents [1 0] :id "A"))
+     (jsx/point (assoc cerise :parents [-1 0] :id "B"))
+     (jsx/point (assoc cerise :parents [0.65 1.45] :id "C"))
+     (jsx/polygon
+      {:parents ["A" "B" "C"]
+       :borders {:ids ["pol_0" "pol_1" "pol_2"]}
+       :fillColor "#FFFF00"
+       :lines {:strokeWidth 2
+               :strokeColor "#009256"}})
+
+     ;; ## Circumcircle
+     (jsx/circumcircle
+      {:parents ["A" "B" "C"]
+       :strokeColor "#000000"
+       :visible circumcenter?
+       :dash 3
+       :strokeWidth 1
+       :center (assoc grass
+                      :name "U"
+                      :visible circumcenter?)})
+
+     ;; ## Orthocenter
+     ;;
+     ;; Altitudes
+     (jsx/perpendicular
+      (assoc perpendicular :parents ["pol_0" "C"] :id "pABC"))
+     (jsx/intersection
+      (assoc cerise
+             :parents ["pol_0" "pABC"]
+             :visible orthocenter?
+             :name "H_c"))
+
+     (jsx/perpendicular
+      (assoc perpendicular :parents ["pol_1" "A"] :id "pBCA"))
+     (jsx/intersection
+      (assoc cerise
+             :parents ["pol_1" "pBCA"]
+             :visible orthocenter?
+             :name "H_a"))
+
+     (jsx/perpendicular
+      (assoc perpendicular :parents ["pol_2" "B"] :id "pCAB"))
+     (jsx/intersection
+      (assoc cerise
+             :parents ["pol_2" "pCAB"]
+             :visible orthocenter?
+             :name "H_b"))
+
+     ;; Intersection of Altitudes
+     (jsx/intersection
+      (assoc grass
+             :visible orthocenter?
+             :id "i1"
+             :name "H"
+             :parents ["pABC" "pCAB" 0]))
+
+     ;; ## Centroid
+     ;;
+     ;; Medians
+     (jsx/midpoint
+      (assoc cerise :name "M_a"
+             :visible centroid?
+             :parents ["B" "C"]))
+     (jsx/segment
+      (assoc median :id "ma"
+             :visible centroid?
+             :parents ["M_a" "A"]))
+
+     (jsx/midpoint
+      (assoc cerise :name "M_b"
+             :visible centroid?
+             :parents ["C" "A"]))
+     (jsx/segment
+      (assoc median :id "mb"
+             :visible centroid?
+             :parents ["M_b" "B"]))
+
+     (jsx/midpoint
+      (assoc cerise :name "M_c"
+             :visible centroid?
+             :parents ["A" "B"]))
+     (jsx/segment
+      (assoc median :id "mc"
+             :visible centroid?
+             :parents ["M_c" "C"]))
+
+     ;; Intersection of Medians
+     (jsx/intersection
+      (assoc grass :id "i2"
+             :visible centroid?
+             :name "S" :parents ["ma" "mc" 0]))
+
+     ;; Euler's Line (intersection of orthocenter and median, but the
+     ;; circumcenter lies on this line as well).
+     (jsx/line
+      {:parents ["i1" "i2"]
+       :strokeWidth 2
+       :strokeColor "#901B77"}))))
+
+
+
+;; ## A 5 Circle Incidence Theorem
+
+;; This is a visualization of A 5-Circle Incidence Theorem by J. Chris Fisher,
+;; Larry Hoehn and Eberhard. M. Schröder From [ Mathematics Magazine, Volume 87,
+;; 2014 - Issue
+;; 1](https://www.tandfonline.com/doi/abs/10.4169/math.mag.87.1.44?journalCode=umma20).
+
+(defn circle-theorem [coords]
+  (apply
+   jsx/jsxgraph
+   {:boundingbox [-5 5 5 -5]
+    :showCopyright false
+    :keepaspectratio true}
+   (concat
+    (map-indexed
+     (fn [k p]
+       (jsx/point
+        {:name "" :id (str "A_" k) :strokeColor "#7355ff" :fillColor "#7355ff"
+         :parents p}))
+     coords)
+
+    (map (fn [k]
+           (jsx/segment
+            {:id (str "s_" k)
+             :strokeColor "blue" :strokeWidth 1
+             :parents [(str "A_" k)
+                       (str "A_" (mod (+ k 2) 5))]}))
+         (range 5))
+
+    (map (fn [k]
+           (jsx/intersection
+            {:id (str "B_" k) :name "" :strokeColor "#EA0000" :fillColor "#EA0000"
+             :parents [(str "s_" k)
+                       (str "s_" (mod (+ (dec k) 5) 5))
+                       0]}))
+         (range 5))
+
+    (map (fn [k]
+           (jsx/circle
+            {:id (str "c_" k) :strokeColor "#aaaaaa" :strokeWidth 1
+             :parents [(str "A_" k)
+                       (str "B_" k)
+                       (str "A_" (mod (inc k) 5))]}))
+         (range 5))
+
+    (map (fn [k]
+           (jsx/radical-axis
+            {:strokeColor "#ff0000" :strokeWidth 2
+             :parents [(str "c_" k)
+                       (str "c_" (mod (+ (dec k) 5) 5))]}))
+         (range 5)))))
+
+;; From the abstract:
+;;
+;; > We state and prove a surprising incidence theorem that was discovered with
+;; > the help of a computer graphics program. The theorem involves sixteen
+;; > points on ten lines and five circles; our proof relies on theorems of
+;; > Euclid, Menelaus, and Ceva. The result bears a striking resemblance to
+;; > Miquel's 5-circle theorem, but as far as we can determine, the relationship
+;; > of our result to known incidence theorems is superficial.
+;;
+;; Unfortunately the article is stuck behind a paywall... I'll see what I can do
+;; to get it out.
+;;
+;; Here are our points:
+
+(def points
+  [[2.5 -3]
+   [2 4]
+   [-2.5 3]
+   [-4 -2]
+   [0 -4]])
+
+;; And our viewer:
+(circle-theorem points)

--- a/dev/emmy_viewers/jsxgraph.clj
+++ b/dev/emmy_viewers/jsxgraph.clj
@@ -1,0 +1,13 @@
+^{:nextjournal.clerk/visibility {:code :hide}}
+(ns emmy-viewers.jsxgraph
+  #:nextjournal.clerk
+  {:toc true :no-cache true}
+  (:require [emmy.clerk :as ec]
+            #_#_[emmy.jsxgraph :as jsx]
+            [emmy.viewer :as ev]
+            [nextjournal.clerk :as-alias clerk]))
+
+;; # JSXGraph Demo
+
+^{::clerk/visibility {:code :hide :result :hide}}
+(ec/install!)

--- a/src/emmy/jsxgraph.clj
+++ b/src/emmy/jsxgraph.clj
@@ -1,0 +1,5 @@
+(ns emmy.jsxgraph
+  "Server-side rendering functions for the components declared in the
+  [`jsxgraph.core`](https://cljdoc.org/d/org.mentat/jsxgraph.cljs/CURRENT/api/jsxgraph.core)
+  namespace of the [`JSXGraph.cljs` project](https://leva.mentat.org)."
+  #_(:require [emmy.viewer :as ev]))

--- a/src/emmy/jsxgraph.clj
+++ b/src/emmy/jsxgraph.clj
@@ -2,4 +2,1281 @@
   "Server-side rendering functions for the components declared in the
   [`jsxgraph.core`](https://cljdoc.org/d/org.mentat/jsxgraph.cljs/CURRENT/api/jsxgraph.core)
   namespace of the [`JSXGraph.cljs` project](https://leva.mentat.org)."
-  #_(:require [emmy.viewer :as ev]))
+  (:require [emmy.viewer :as ev]))
+
+;; ## Main Component
+
+(defn jsxgraph
+  "Top-level Reagent component used to represent a JSXGraph board. Takes
+
+  - a `keyword => value` map of attributes (see the `attributes` section under
+    `Parameters` at [this
+    page](https://jsxgraph.org/docs/symbols/JXG.JSXGraph.html)) for allowed values
+
+  - Any number of child components representing `JSXGraph` elements.
+
+  Child components are added to the board in the order that they're listed. A
+  full re-render is triggered any time any of the properties of the board or any
+  child component changes.
+
+  Pass `:id` and/or `:style` to configure the `div` into which the controlled
+  instance of `JXG.Board` mounts itself.
+
+  If you need access to the actual instance of
+  a [`JXG.Board`](https://jsxgraph.org/docs/symbols/JXG.Board.html), pass a
+  callback function using the `:ref` keyword. The `:ref` function receives an
+  instance of the board when it is mounted, and `nil` when the board is
+  destroyed or remounted."
+  [& children]
+  (ev/fragment
+   (into ['jsxgraph.core/JSXGraph] children)))
+
+;; ## Child Components
+
+(defn angle
+  "Fragment that represents a Reagent component representing
+  the [Angle](https://jsxgraph.org/docs/symbols/Angle.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Angle.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Angle opts]))
+
+(defn arc
+  "Fragment that represents a Reagent component representing
+  the [Arc](https://jsxgraph.org/docs/symbols/Arc.html) JSXGraph element. This
+  component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Arc.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Arc opts]))
+
+(defn arrow
+  "Fragment that represents a Reagent component representing
+  the [Arrow](https://jsxgraph.org/docs/symbols/Arrow.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Arrow.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Arrow opts]))
+
+(defn arrow-parallel
+  "Fragment that represents a Reagent component representing
+  the [ArrowParallel](https://jsxgraph.org/docs/symbols/ArrowParallel.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/ArrowParallel.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/ArrowParallel opts]))
+
+(defn axis
+  "Fragment that represents a Reagent component representing
+  the [Axis](https://jsxgraph.org/docs/symbols/Axis.html) JSXGraph element. This
+  component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Axis.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Axis opts]))
+
+(defn bisector
+  "Fragment that represents a Reagent component representing
+  the [Bisector](https://jsxgraph.org/docs/symbols/Bisector.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Bisector.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Bisector opts]))
+
+(defn bisector-lines
+  "Fragment that represents a Reagent component representing
+  the [Bisectorlines](https://jsxgraph.org/docs/symbols/Bisectorlines.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Bisectorlines.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Bisectorlines opts]))
+
+(defn boxplot
+  "Fragment that represents a Reagent component representing
+  the [Boxplot](https://jsxgraph.org/docs/symbols/Boxplot.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Boxplot.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Boxplot opts]))
+
+(defn button
+  "Fragment that represents a Reagent component representing
+  the [Button](https://jsxgraph.org/docs/symbols/Button.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Button.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Button opts]))
+
+(defn cardinal-spline
+  "Fragment that represents a Reagent component representing
+  the [CardinalSpline](https://jsxgraph.org/docs/symbols/CardinalSpline.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/CardinalSpline.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/CardinalSpline opts]))
+
+(defn chart
+  "Fragment that represents a Reagent component representing
+  the [Chart](https://jsxgraph.org/docs/symbols/Chart.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Chart.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Chart opts]))
+
+(defn checkbox
+  "Fragment that represents a Reagent component representing
+  the [Checkbox](https://jsxgraph.org/docs/symbols/Checkbox.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Checkbox.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Checkbox opts]))
+
+(defn circle
+  "Fragment that represents a Reagent component representing
+  the [Circle](https://jsxgraph.org/docs/symbols/Circle.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Circle.html), the map must contain an
+  "
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Circle opts]))
+
+(defn circumcenter
+  "Fragment that represents a Reagent component representing
+  the [Circumcenter](https://jsxgraph.org/docs/symbols/Circumcenter.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Circumcenter.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Circumcenter opts]))
+
+(defn circumcircle
+  "Fragment that represents a Reagent component representing
+  the [Circumcircle](https://jsxgraph.org/docs/symbols/Circumcircle.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Circumcircle.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Circumcircle opts]))
+
+(defn circumcircle-arc
+  "Fragment that represents a Reagent component representing
+  the [CircumcircleArc](https://jsxgraph.org/docs/symbols/CircumcircleArc.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/CircumcircleArc.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/CircumcircleArc opts]))
+
+(defn circumcircle-sector
+  "Fragment that represents a Reagent component representing
+  the [CircumcircleSector](https://jsxgraph.org/docs/symbols/CircumcircleSector.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/CircumcircleSector.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/CircumcircleSector opts]))
+
+(defn comb
+  "Fragment that represents a Reagent component representing
+  the [Comb](https://jsxgraph.org/docs/symbols/Comb.html) JSXGraph element. This
+  component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Comb.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Comb opts]))
+
+(defn conic
+  "Fragment that represents a Reagent component representing
+  the [Conic](https://jsxgraph.org/docs/symbols/Conic.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Conic.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Conic opts]))
+
+(defn curve
+  "Fragment that represents a Reagent component representing
+  the [Curve](https://jsxgraph.org/docs/symbols/Curve.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Curve.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Curve opts]))
+
+(defn curve-difference
+  "Fragment that represents a Reagent component representing
+  the [CurveDifference](https://jsxgraph.org/docs/symbols/CurveDifference.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/CurveDifference.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/CurveDifference opts]))
+
+(defn curve-intersection
+  "Fragment that represents a Reagent component representing
+  the [CurveIntersection](https://jsxgraph.org/docs/symbols/CurveIntersection.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/CurveIntersection.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/CurveIntersection opts]))
+
+(defn curve-union
+  "Fragment that represents a Reagent component representing
+  the [CurveUnion](https://jsxgraph.org/docs/symbols/CurveUnion.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/CurveUnion.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/CurveUnion opts]))
+
+(defn derivative
+  "Fragment that represents a Reagent component representing
+  the [Derivative](https://jsxgraph.org/docs/symbols/Derivative.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Derivative.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Derivative opts]))
+
+(defn ellipse
+  "Fragment that represents a Reagent component representing
+  the [Ellipse](https://jsxgraph.org/docs/symbols/Ellipse.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Ellipse.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Ellipse opts]))
+
+(defn foreign-object
+  "Fragment that represents a Reagent component representing
+  the [ForeignObject](https://jsxgraph.org/docs/symbols/ForeignObject.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/ForeignObject.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/ForeignObject opts]))
+
+(defn function-graph
+  "Fragment that represents a Reagent component representing
+  the [FunctionGraph](https://jsxgraph.org/docs/symbols/FunctionGraph.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/FunctionGraph.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/FunctionGraph opts]))
+
+(defn glider
+  "Fragment that represents a Reagent component representing
+  the [Glider](https://jsxgraph.org/docs/symbols/Glider.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Glider.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Glider opts]))
+
+(defn grid
+  "Fragment that represents a Reagent component representing
+  the [Grid](https://jsxgraph.org/docs/symbols/Grid.html) JSXGraph element. This
+  component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Grid.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Grid opts]))
+
+(defn group
+  "Fragment that represents a Reagent component representing
+  the [Group](https://jsxgraph.org/docs/symbols/Group.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Group.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Group opts]))
+
+(defn hatch
+  "Fragment that represents a Reagent component representing
+  the [Hatch](https://jsxgraph.org/docs/symbols/Hatch.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Hatch.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Hatch opts]))
+
+(defn hyperbola
+  "Fragment that represents a Reagent component representing
+  the [Hyperbola](https://jsxgraph.org/docs/symbols/Hyperbola.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Hyperbola.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Hyperbola opts]))
+
+(defn image
+  "Fragment that represents a Reagent component representing
+  the [Image](https://jsxgraph.org/docs/symbols/Image.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Image.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Image opts]))
+
+(defn incenter
+  "Fragment that represents a Reagent component representing
+  the [Incenter](https://jsxgraph.org/docs/symbols/Incenter.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Incenter.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Incenter opts]))
+
+(defn incircle
+  "Fragment that represents a Reagent component representing
+  the [Incircle](https://jsxgraph.org/docs/symbols/Incircle.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Incircle.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Incircle opts]))
+
+(defn inequality
+  "Fragment that represents a Reagent component representing
+  the [Inequality](https://jsxgraph.org/docs/symbols/Inequality.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Inequality.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Inequality opts]))
+
+(defn input
+  "Fragment that represents a Reagent component representing
+  the [Input](https://jsxgraph.org/docs/symbols/Input.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Input.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Input opts]))
+
+(defn integral
+  "Fragment that represents a Reagent component representing
+  the [Integral](https://jsxgraph.org/docs/symbols/Integral.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Integral.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Integral opts]))
+
+(defn intersection
+  "Fragment that represents a Reagent component representing
+  the [Intersection](https://jsxgraph.org/docs/symbols/Intersection.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Intersection.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Intersection opts]))
+
+(defn label
+  "Fragment that represents a Reagent component representing
+  the [Label](https://jsxgraph.org/docs/symbols/Label.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Label.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Label opts]))
+
+(defn legend
+  "Fragment that represents a Reagent component representing
+  the [Legend](https://jsxgraph.org/docs/symbols/Legend.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Legend.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Legend opts]))
+
+(defn line
+  "Fragment that represents a Reagent component representing
+  the [Line](https://jsxgraph.org/docs/symbols/Line.html) JSXGraph element. This
+  component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Line.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Line opts]))
+
+(defn locus
+  "Fragment that represents a Reagent component representing
+  the [Locus](https://jsxgraph.org/docs/symbols/Locus.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Locus.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Locus opts]))
+
+(defn major-arc
+  "Fragment that represents a Reagent component representing
+  the [MajorArc](https://jsxgraph.org/docs/symbols/MajorArc.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/MajorArc.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/MajorArc opts]))
+
+(defn major-sector
+  "Fragment that represents a Reagent component representing
+  the [MajorSector](https://jsxgraph.org/docs/symbols/MajorSector.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/MajorSector.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/MajorSector opts]))
+
+(defn metapost-spline
+  "Fragment that represents a Reagent component representing
+  the [MetapostSpline](https://jsxgraph.org/docs/symbols/MetapostSpline.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/MetapostSpline.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/MetapostSpline opts]))
+
+(defn midpoint
+  "Fragment that represents a Reagent component representing
+  the [Midpoint](https://jsxgraph.org/docs/symbols/Midpoint.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Midpoint.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Midpoint opts]))
+
+(defn minor-arc
+  "Fragment that represents a Reagent component representing
+  the [MinorArc](https://jsxgraph.org/docs/symbols/MinorArc.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/MinorArc.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/MinorArc opts]))
+
+(defn minor-sector
+  "Fragment that represents a Reagent component representing
+  the [MinorSector](https://jsxgraph.org/docs/symbols/MinorSector.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/MinorSector.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/MinorSector opts]))
+
+(defn mirror-element
+  "Fragment that represents a Reagent component representing
+  the [MirrorElement](https://jsxgraph.org/docs/symbols/MirrorElement.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/MirrorElement.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/MirrorElement opts]))
+
+(defn mirror-point
+  "Fragment that represents a Reagent component representing
+  the [MirrorPoint](https://jsxgraph.org/docs/symbols/MirrorPoint.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/MirrorPoint.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/MirrorPoint opts]))
+
+(defn non-reflex-angle
+  "Fragment that represents a Reagent component representing
+  the [NonReflexAngle](https://jsxgraph.org/docs/symbols/NonReflexAngle.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/NonReflexAngle.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/NonReflexAngle opts]))
+
+(defn normal
+  "Fragment that represents a Reagent component representing
+  the [Normal](https://jsxgraph.org/docs/symbols/Normal.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Normal.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Normal opts]))
+
+(defn orthogonal-projection
+  "Fragment that represents a Reagent component representing
+  the [OrthogonalProjection](https://jsxgraph.org/docs/symbols/OrthogonalProjection.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/OrthogonalProjection.html), the map
+  must contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/OrthogonalProjection opts]))
+
+(defn other-intersection
+  "Fragment that represents a Reagent component representing
+  the [OtherIntersection](https://jsxgraph.org/docs/symbols/OtherIntersection.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/OtherIntersection.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/OtherIntersection opts]))
+
+(defn parabola
+  "Fragment that represents a Reagent component representing
+  the [Parabola](https://jsxgraph.org/docs/symbols/Parabola.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Parabola.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Parabola opts]))
+
+(defn parallel
+  "Fragment that represents a Reagent component representing
+  the [Parallel](https://jsxgraph.org/docs/symbols/Parallel.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Parallel.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Parallel opts]))
+
+(defn parallel-point
+  "Fragment that represents a Reagent component representing
+  the [ParallelPoint](https://jsxgraph.org/docs/symbols/ParallelPoint.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/ParallelPoint.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/ParallelPoint opts]))
+
+(defn perpendicular
+  "Fragment that represents a Reagent component representing
+  the [Perpendicular](https://jsxgraph.org/docs/symbols/Perpendicular.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Perpendicular.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Perpendicular opts]))
+
+(defn perpendicular-point
+  "Fragment that represents a Reagent component representing
+  the [PerpendicularPoint](https://jsxgraph.org/docs/symbols/PerpendicularPoint.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/PerpendicularPoint.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/PerpendicularPoint opts]))
+
+(defn perpendicular-segment
+  "Fragment that represents a Reagent component representing
+  the [PerpendicularSegment](https://jsxgraph.org/docs/symbols/PerpendicularSegment.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/PerpendicularSegment.html), the map
+  must contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/PerpendicularSegment opts]))
+
+(defn point
+  "Fragment that represents a Reagent component representing
+  the [Point](https://jsxgraph.org/docs/symbols/Point.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Point.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Point opts]))
+
+(defn polar-line
+  "Fragment that represents a Reagent component representing
+  the [PolarLine](https://jsxgraph.org/docs/symbols/PolarLine.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/PolarLine.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/PolarLine opts]))
+
+(defn pole-point
+  "Fragment that represents a Reagent component representing
+  the [PolePoint](https://jsxgraph.org/docs/symbols/PolePoint.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/PolePoint.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/PolePoint opts]))
+
+(defn polygon
+  "Fragment that represents a Reagent component representing
+  the [Polygon](https://jsxgraph.org/docs/symbols/Polygon.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Polygon.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Polygon opts]))
+
+(defn polygonal-chain
+  "Fragment that represents a Reagent component representing
+  the [PolygonalChain](https://jsxgraph.org/docs/symbols/PolygonalChain.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/PolygonalChain.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/PolygonalChain opts]))
+
+(defn radical-axis
+  "Fragment that represents a Reagent component representing
+  the [RadicalAxis](https://jsxgraph.org/docs/symbols/RadicalAxis.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/RadicalAxis.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/RadicalAxis opts]))
+
+(defn reflection
+  "Fragment that represents a Reagent component representing
+  the [Reflection](https://jsxgraph.org/docs/symbols/Reflection.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Reflection.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Reflection opts]))
+
+(defn reflex-angle
+  "Fragment that represents a Reagent component representing
+  the [ReflexAngle](https://jsxgraph.org/docs/symbols/ReflexAngle.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/ReflexAngle.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/ReflexAngle opts]))
+
+(defn regular-polygon
+  "Fragment that represents a Reagent component representing
+  the [RegularPolygon](https://jsxgraph.org/docs/symbols/RegularPolygon.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/RegularPolygon.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/RegularPolygon opts]))
+
+(defn riemann-sum
+  "Fragment that represents a Reagent component representing
+  the [RiemannSum](https://jsxgraph.org/docs/symbols/RiemannSum.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/RiemannSum.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/RiemannSum opts]))
+
+(defn sector
+  "Fragment that represents a Reagent component representing
+  the [Sector](https://jsxgraph.org/docs/symbols/Sector.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Sector.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Sector opts]))
+
+(defn segment
+  "Fragment that represents a Reagent component representing
+  the [Segment](https://jsxgraph.org/docs/symbols/Segment.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Segment.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Segment opts]))
+
+(defn semicircle
+  "Fragment that represents a Reagent component representing
+  the [Semicircle](https://jsxgraph.org/docs/symbols/Semicircle.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Semicircle.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Semicircle opts]))
+
+(defn slider
+  "Fragment that represents a Reagent component representing
+  the [Slider](https://jsxgraph.org/docs/symbols/Slider.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Slider.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Slider opts]))
+
+(defn slope-triangle
+  "Fragment that represents a Reagent component representing
+  the [SlopeTriangle](https://jsxgraph.org/docs/symbols/SlopeTriangle.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/SlopeTriangle.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/SlopeTriangle opts]))
+
+(defn spline
+  "Fragment that represents a Reagent component representing
+  the [Spline](https://jsxgraph.org/docs/symbols/Spline.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Spline.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Spline opts]))
+
+(defn step-function
+  "Fragment that represents a Reagent component representing
+  the [StepFunction](https://jsxgraph.org/docs/symbols/StepFunction.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/StepFunction.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/StepFunction opts]))
+
+(defn tangent
+  "Fragment that represents a Reagent component representing
+  the [Tangent](https://jsxgraph.org/docs/symbols/Tangent.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Tangent.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Tangent opts]))
+
+(defn tape-measure
+  "Fragment that represents a Reagent component representing
+  the [TapeMeasure](https://jsxgraph.org/docs/symbols/TapeMeasure.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/TapeMeasure.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/TapeMeasure opts]))
+
+(defn text
+  "Fragment that represents a Reagent component representing
+  the [Text](https://jsxgraph.org/docs/symbols/Text.html) JSXGraph element. This
+  component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Text.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Text opts]))
+
+(defn ticks
+  "Fragment that represents a Reagent component representing
+  the [Ticks](https://jsxgraph.org/docs/symbols/Ticks.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Ticks.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Ticks opts]))
+
+(defn trace-curve
+  "Fragment that represents a Reagent component representing
+  the [TraceCurve](https://jsxgraph.org/docs/symbols/TraceCurve.html) JSXGraph
+  element. This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/TraceCurve.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/TraceCurve opts]))
+
+(defn transformation
+  "Fragment that represents a Reagent component representing
+  the [Transformation](https://jsxgraph.org/docs/symbols/Transformation.html)
+  JSXGraph element. This component must appear as a child of a [[jsxgraph]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Transformation.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Transformation opts]))
+
+(defn turtle
+  "Fragment that represents a Reagent component representing
+  the [Turtle](https://jsxgraph.org/docs/symbols/Turtle.html) JSXGraph element.
+  This component must appear as a child of a [[jsxgraph]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Turtle.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+  [opts]
+  (ev/fragment
+   ['jsxgraph.core/Turtle opts]))
+
+;; ## 3D Components
+;;
+;; These aren't yet supported! Once [this
+;; ticket](https://github.com/mentat-collective/jsxgraph.cljs/issues/23) is
+;; resolved and we can create 3d scenes we can uncomment these and include them
+;; in the API.
+
+(comment
+  (defn curve-3d
+    "Fragment that represents a Reagent component representing
+  the [Curve3D](https://jsxgraph.org/docs/symbols/Curve3D.html) JSXGraph
+  element. This component must appear as a child of a [[view-3d]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Curve3D.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+    [opts]
+    (ev/fragment
+     ['jsxgraph.core/Curve3D opts]))
+
+  (defn function-graph-3d
+    "Fragment that represents a Reagent component representing
+  the [FunctionGraph3D](https://jsxgraph.org/docs/symbols/FunctionGraph3D.html)
+  JSXGraph element. This component must appear as a child of a [[view-3d]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/FunctionGraph3D.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
+    [opts]
+    (ev/fragment
+     ['jsxgraph.core/FunctionGraph3D opts]))
+
+  (defn line-3d
+    "Fragment that represents a Reagent component representing
+  the [Line3D](https://jsxgraph.org/docs/symbols/Line3D.html) JSXGraph element.
+  This component must appear as a child of a [[view-3d]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Line3D.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+    [opts]
+    (ev/fragment
+     ['jsxgraph.core/Line3D opts]))
+
+  (defn parametric-surface-3d
+    "Fragment that represents a Reagent component representing
+  the [ParametricSurface3D](https://jsxgraph.org/docs/symbols/ParametricSurface3D.html)
+  JSXGraph element. This component must appear as a child of a [[view-3d]]
+  component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/ParametricSurface3D.html), the map
+  must contain an entry `:parents` with value containing the element's required
+  parents."
+    [opts]
+    (ev/fragment
+     ['jsxgraph.core/ParametricSurface3D opts]))
+
+  (defn point-3d
+    "Fragment that represents a Reagent component representing
+  the [Point3D](https://jsxgraph.org/docs/symbols/Point3D.html) JSXGraph
+  element. This component must appear as a child of a [[view-3d]] component.
+
+  The element takes a single map of attributes. In addition to the optional
+  attributes specified in the [API
+  docs](https://jsxgraph.org/docs/symbols/Point3D.html), the map must contain an
+  entry `:parents` with value containing the element's required parents."
+    [opts]
+    (ev/fragment
+     ['jsxgraph.core/Point3D opts])))

--- a/src/emmy/portal.clj
+++ b/src/emmy/portal.clj
@@ -13,7 +13,8 @@
   ["emmy/portal/tex.cljs"
    "emmy/portal/reagent.cljs"
    "emmy/portal/mafs.cljs"
-   "emmy/portal/leva.cljs"])
+   "emmy/portal/leva.cljs"
+   "emmy/portal/jsxgraph.cljs"])
 
 (defn prepare!
   "Installs any npm dependencies specified by a `deps.cljs` file in some

--- a/src/emmy/portal/jsxgraph.cljs
+++ b/src/emmy/portal/jsxgraph.cljs
@@ -1,0 +1,27 @@
+(ns emmy.portal.jsxgraph
+  "Portal viewer for rendering JSXGraph.cljs reagent snippets. Requiring this
+  viewer has the side-effect of requiring all namespaces
+  from [JSXGraph.cljs](https://github.com/mentat-collective/JSXGraph.cljs) into
+  the SCI context.
+
+  Generate these fragments using the code in the [[emmy.jsxgraph]] namespace and
+  sub-namespaces.
+
+  To use this viewer, first install the `leva` npm package:
+
+  ```bash
+  npm install jsxgraph@1.5.0
+  ```
+
+  Then install the viewer:
+
+  ```clojure
+  (emmy.portal/install! \"emmy/portal/jsxgraph.cljs\")
+  ```
+
+  The viewer is automatically installed by the functions in [[emmy.portal]]."
+  (:require [emmy.viewer.css :refer [css-map]]
+            [emmy.portal.css :as css]
+            [jsxgraph.core]))
+
+(apply css/inject! (:jsxgraph css-map))

--- a/src/emmy/portal/leva.cljs
+++ b/src/emmy/portal/leva.cljs
@@ -1,10 +1,10 @@
 (ns emmy.portal.leva
   "Portal viewer for rendering Leva.cljs reagent snippets. Requiring this viewer
   has the side-effect of requiring all namespaces
-  from [Mafs.cljs](https://github.com/mentat-collective/Leva.cljs) into the SCI
+  from [Leva.cljs](https://github.com/mentat-collective/Leva.cljs) into the SCI
   context.
 
-  Generate these fragments using the code in the [[emmy.mafs]] namespace and
+  Generate these fragments using the code in the [[emmy.leva]] namespace and
   sub-namespaces.
 
   To use this viewer, first install the `leva` npm package:


### PR DESCRIPTION
- #31:

  - Adds `emmy.jsxgraph`, with functions for creating Reagent fragments that
    configure the components from [JSXGraph.cljs](https://jsxgraph.mentat.org/)
    for Portal or Clerk

  - `dev/emmy_viewers/jsxgraph.clj` shows off some basic demos, though these are
    not yet organized

  - `emmy/portal/jsxgraph.cljs` gives Portal the ability to render Leva
    components by loading JSXGraph into portal's SCI context.