### PR TITLE
MathLive server-side component, Clerk and Portal support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [unreleased]
 
+- #32:
+
+  - Adds `emmy.mathlive`, with functions for creating Reagent fragments that
+    configure the components from [MathLive.cljs](https://mathlive.mentat.org/)
+    for Portal or Clerk
+
+  - `dev/emmy_viewers/mathlive.clj` shows off a basic demo
+
+  - `emmy/portal/mathlive.cljs` gives Portal the ability to render MathLive
+    Mathfield instances by loading MathLive into portal's SCI context.
+
 - #31:
 
   - Adds `emmy.jsxgraph`, with functions for creating Reagent fragments that
@@ -11,7 +22,7 @@
   - `dev/emmy_viewers/jsxgraph.clj` shows off some basic demos, though these are
     not yet organized
 
-  - `emmy/portal/jsxgraph.cljs` gives Portal the ability to render Leva
+  - `emmy/portal/jsxgraph.cljs` gives Portal the ability to render JSXGraph
     components by loading JSXGraph into portal's SCI context.
 
 - #29:

--- a/dev/emmy_viewers/mathlive.clj
+++ b/dev/emmy_viewers/mathlive.clj
@@ -1,0 +1,21 @@
+^{:nextjournal.clerk/visibility {:code :hide}}
+(ns emmy-viewers.mathlive
+  #:nextjournal.clerk
+  {:toc true :no-cache true}
+  (:require [emmy.clerk :as ec]
+            [emmy.mathlive :as ml]
+            [nextjournal.clerk :as-alias clerk]))
+
+;; # MathLive Demo
+
+^{::clerk/visibility {:code :hide :result :hide}}
+(ec/install!)
+
+
+;; There has to be a better way... but for now, render this to set style:
+
+ml/style
+
+;; And here's a mathfield:
+
+(ml/mathfield)

--- a/dev/examples/portal.clj
+++ b/dev/examples/portal.clj
@@ -6,6 +6,7 @@
             [emmy.env :as e :refer :all]
             [emmy.leva :as leva]
             [emmy.mafs :as mafs]
+            [emmy.mathlive :as ml]
             [emmy.portal :as p]
             [emmy.viewer :as ev]
             [portal.api]))
@@ -17,6 +18,9 @@
     (p/start!
      {:emmy.portal/tex {:macros {"\\f" "#1f(#2)"}}
       :theme :portal.colors/zenburn}))
+
+  (tap>
+   (ml/mathfield {:default-value "1+x"}))
 
   (tap>
    (emmy.mafs.core/mafs-meta

--- a/src/emmy/mathlive.clj
+++ b/src/emmy/mathlive.clj
@@ -1,0 +1,44 @@
+(ns emmy.mathlive
+  "Server-side rendering functions for the components declared in the
+  [`mathlive.core`](https://cljdoc.org/d/org.mentat/mathlive.cljs/CURRENT/api/mathlive.core)
+  namespace of the [`MathLive.cljs` project](https://mathlive.mentat.org)."
+  (:require [emmy.viewer :as ev]))
+
+;; ## MathLive Components
+;;
+;; This is all quite alpha at the moment. A better version of this code will be
+;; able to translate between Emmy expressions and what's rendered.
+
+(defn ^:no-doc mathlive-meta [v]
+  (vary-meta v assoc
+             :portal.viewer/mathlive? true
+             :portal.viewer/default :emmy.portal/mathlive))
+
+(def style
+  "Place this fragment in a Clerk notebook to set the default styles
+  for [[mathfield]] instances in the notebook."
+  (ev/fragment
+   [:style "
+math-field {
+  width: 100%;
+  font-size: 24px;
+  border-radius: 4px;
+  border: 1px solid;
+  padding: 8px;
+}
+math-field:focus-within {
+  outline: none;
+  border: 1px solid blue;
+}"]))
+
+(defn mathfield
+  "Given a map of options `opts`, returns a Reagent fragment that mounts an
+  instance of the [MathLive](https://github.com/arnog/mathlive) equation editor.
+
+  NOTE: Following React's convention, `:on-change` binds a listener to to the
+  `input` event. See https://reactjs.org/docs/dom-elements.html#onchange"
+  ([] (mathfield {}))
+  ([opts]
+   (mathlive-meta
+    (ev/fragment
+     ['mathlive.core/Mathfield opts]))))

--- a/src/emmy/portal.clj
+++ b/src/emmy/portal.clj
@@ -14,7 +14,8 @@
    "emmy/portal/reagent.cljs"
    "emmy/portal/mafs.cljs"
    "emmy/portal/leva.cljs"
-   "emmy/portal/jsxgraph.cljs"])
+   "emmy/portal/jsxgraph.cljs"
+   "emmy/portal/mathlive.cljs"])
 
 (defn prepare!
   "Installs any npm dependencies specified by a `deps.cljs` file in some

--- a/src/emmy/portal/jsxgraph.cljs
+++ b/src/emmy/portal/jsxgraph.cljs
@@ -7,7 +7,7 @@
   Generate these fragments using the code in the [[emmy.jsxgraph]] namespace and
   sub-namespaces.
 
-  To use this viewer, first install the `leva` npm package:
+  To use this viewer, first install the `jsxgraph` npm package:
 
   ```bash
   npm install jsxgraph@1.5.0

--- a/src/emmy/portal/mathlive.cljs
+++ b/src/emmy/portal/mathlive.cljs
@@ -1,0 +1,60 @@
+(ns emmy.portal.mathlive
+  "Portal viewer for rendering MathLive.cljs reagent snippets. Requiring this
+  viewer has the side-effect of requiring all namespaces
+  from [MathLive.cljs](https://github.com/mentat-collective/MathLive.cljs) into
+  the SCI context.
+
+  Generate these fragments using the code in the [[emmy.mathlive]] namespace and
+  sub-namespaces.
+
+  To use this viewer, first install the `mathlive` npm package:
+
+  ```bash
+  npm install mathlive@0.85.1
+  ```
+
+  Then install the viewer:
+
+  ```clojure
+  (emmy.portal/install! \"emmy/portal/mathlive.cljs\")
+  ```
+
+  The viewer is automatically installed by the functions in [[emmy.portal]]."
+  (:require [emmy.viewer.css :refer [css-map]]
+            [emmy.portal.css :as css]
+            [emmy.portal.reagent :as pr]
+            [mathlive.core]
+            [portal.ui.api :as p]))
+
+(apply css/inject! (:mathlive css-map))
+
+(def viewer-name :emmy.portal/mathlive)
+
+(def style "
+math-field {
+  width: 100%;
+  font-size: 24px;
+  border-radius: 4px;
+  border: 1px solid;
+  padding: 8px;
+}
+math-field:focus-within {
+  outline: none;
+  border: 1px solid blue;
+}")
+
+(defn show-mathlive [v]
+  [:div
+   [:style style]
+   [pr/show-reagent v]])
+
+(p/register-viewer!
+ {:name viewer-name
+  :component show-mathlive
+  :predicate
+  (fn [v]
+    (when-let [m (meta v)]
+      (or (:portal.viewer/mathlive? m)
+          (:portal.viewer/reagent? m)
+          (= viewer-name
+             (:portal.viewer/default m)))))})


### PR DESCRIPTION
- #32:

  - Adds `emmy.mathlive`, with functions for creating Reagent fragments that
    configure the components from [MathLive.cljs](https://mathlive.mentat.org/)
    for Portal or Clerk

  - `dev/emmy_viewers/mathlive.clj` shows off a basic demo

  - `emmy/portal/mathlive.cljs` gives Portal the ability to render MathLive
    Mathfield instances by loading MathLive into portal's SCI context.