### PR TITLE
Fix examples, extract compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [unreleased]
 
+- #39:
+
+  - moves `emmy.mafs.compile` to `emmy.viewer.compile`, for future use by
+    MathBox.
+
+  - ports examples over the new style with `emmy.clerk` and friends.
+
 - #34 renames `emmy-viewers.sci` to `emmy.viewer.sci`.
 
 - #30:

--- a/dev/examples/expression.clj
+++ b/dev/examples/expression.clj
@@ -1,14 +1,13 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.expression
+  #:nextjournal.clerk {:toc true}
   (:refer-clojure
    :exclude [+ - * / = zero? compare numerator denominator ref partial])
-  (:require [mentat.clerk-utils.viewers :refer [q]]
-            [nextjournal.clerk :as clerk]
+  (:require [nextjournal.clerk :as clerk]
             [nextjournal.clerk.viewer :as-alias viewer]
             [emmy.env :as e :refer [+ * / ->TeX cos expt simplify sin square]]
             [emmy.expression :as x]
+            [emmy.clerk :as ec]
             [emmy.value :as v]
             [reagent.core :as-alias reagent]))
 
@@ -45,56 +44,24 @@
 
 (defn transform-literal [l]
   (let [simple (simplify l)]
-    {:simplified_TeX (clerk/tex (->TeX simple))
-     :simplified     (v/freeze simple)
-     :TeX            (clerk/tex (->TeX l))
-     :original       (v/freeze l)}))
+    [["simplified TeX" (clerk/tex (->TeX simple))]
+     [:simplified     (v/freeze simple)]
+     [:TeX            (clerk/tex (->TeX l))]
+     [:original       (v/freeze l)]]))
 
 ;; Try it out:
+
 
 (transform-literal
  (+ (square (sin 'x)) (square (cos 'x))))
 
-;; Okay, the tricky part here for me was that we are actually dealing with
-;; wrapped values all over, and we need to extract that and run updates there.
-;; Those are also what show up on the other side of the wire.
-
-(defn literal-viewer [xform]
-  {;; Only apply to these forms.
-   :pred x/literal?
-
-   ;; We have to preserve keys because we want to access the keys in the render
-   ;; function, and by default everything gets recursively wrapped. This feels a
-   ;; little wacky.
-   :transform-fn (comp clerk/mark-preserve-keys
-                       (clerk/update-val
-                        (memoize xform)))
-   :render-fn
-   (q
-    (fn [x]
-      (viewer/html
-       (reagent/with-let [!sel (reagent/atom (ffirst x))]
-         [:<>
-          (into
-           [:div.flex.items-center.font-sans.text-xs.mb-3
-            [:span.text-slate-500.mr-2 "View as:"]]
-           (map (fn [[l _]]
-                  [:button.px-3.py-1.font-medium.hover:bg-indigo-50.rounded-full.hover:text-indigo-600.transition
-                   {:class (if (= @!sel l)
-                             "bg-indigo-100 text-indigo-600"
-                             "text-slate-500")
-                    :on-click #(reset! !sel l)}
-                   l])
-                x))
-          ;; I guess here the value is a data structure with its viewer info
-          ;; embedded.
-          [viewer/inspect-presented
-           (get x @!sel)]]))))})
+;; does it work with the multiviewer?
 
 (def multiviewer
-  (literal-viewer transform-literal))
-
-;; does it work?
+  {:pred x/literal?
+   :transform-fn
+   (clerk/update-val
+    (comp ec/multi transform-literal))})
 
 (clerk/with-viewer multiviewer
   (+ (square (sin 'x))
@@ -103,13 +70,7 @@
 ;; woohoo! We can set it as default viewer for literals in this
 ;; namespace. (Uncomment this form and run `clerk-show` again...)
 
-#_
-(clerk/add-viewers! [multiviewer])
-
-;; If you made a mistake you can totally replace or reset the viewer with:
-
-#_
-(clerk/reset-viewers! (into [multiviewer] (clerk/get-default-viewers)))
+#_(clerk/add-viewers! [multiviewer])
 
 (+ (square (sin 'x))
    (square (cos 'x)))

--- a/dev/examples/functions.clj
+++ b/dev/examples/functions.clj
@@ -1,190 +1,21 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.functions
+  #:nextjournal.clerk{:toc true}
   (:refer-clojure
-   :exclude [+ - * / = zero? compare
-             numerator denominator ref partial])
-  (:require [examples.expression :as d]
-            [mentat.clerk-utils.viewers :refer [q]]
-            [mathbox.core :as-alias mathbox]
-            [mathbox.primitives :as-alias mb]
-            [nextjournal.clerk :as clerk]
+   :exclude [+ - * / = zero? compare numerator denominator ref partial
+             infinite? abs])
+  (:require [emmy.clerk :as ec]
             [emmy.env :as e :refer :all]
-            [emmy.expression.compile :as xc]
-            [emmy.polynomial :as poly]))
+            [emmy.mafs :as mafs]))
 
-;; ## Function Viewer
+^{:nextjournal.clerk/visibility {:code :hide :result :hide}}
+(ec/install!)
+
+;; ## Mafs
 ;;
-;; This namespace demos a viewer for function objects; these are functions that
-;; _work_ locally, you can call them in the REPL, but you can also send them
-;; over the wire to be rendered in the browser.
+;; Mafs is the way to view functions, no doubt.
 
-;;
-;; ### Function Compilation
-;;
-;; Let's assume that the value we will send to the viewer is Clojure function.
-;; How do we get the function over to the browser?
-;;
-;; We can't serialize it directly. What we _can_ do is use SICMUtil's function
-;; compiler in `:source` mode to generate a hygienic function literal.
-;;
-;; Clojure is built out of its own data structures, so that will serialize
-;; nicely.
-
-(defn- fn-transform [f]
-  (xc/compile-fn f 2 {:mode :source}))
-
-;; Let's try it:
-
-(fn-transform
- (fn [x _]
-   (+ (square x)
-      (cube x))))
-
-;; Not too pretty. We can reuse `d/->pretty-str` here (and already it's obvious
-;; that a better presentation would have made `fn-transform` act on the
-;; function, not the FULL map, but whatever):
-
-(clerk/code
- (fn-transform
-  (fn [x _]
-    (+ (square x)
-       (cube x)))))
-
-;; That will work.
-;;
-;; On the client side, we can use SICMUtil's
-;; `sicmutils.expression.compile/sci-eval` function to evaluate (using SCI) this
-;; code-shaped data structure into a proper procedure.
-;;
-;; Look at `Function1` in `src/demo/mathbox_react.cljs` to see what we will DO
-;; with this procedure in the browser.
-;;
-;; ### Rendering
-;;
-;; Now that we have a function literal we need to build our viewer. We will be
-;; sending a hand-crafted function literal over the wire to Clerk's browser
-;; environment. This function will accept the result of `(fn-transform
-;; <original-value>)` after it's been serialized over to the browser.
-;;
-;; This environment is very powerful, and has reagent and many other features
-;; available out of the box. This project customizes the viewer to add in more
-;; functions; see `src/demo/viewers.cljs` for the suite of additions, and feel
-;; free to add your own.
-;;
-;; Here is a function literal that configures a canvas for Mathbox to live in,
-;; and does my currently-best-available poor imitation of React, by
-;;
-;; - Setting up a Mathbox scene on first load
-;; - Blowing away all elements and fully re-rendering the scene on any change to
-;;   the incoming value.
-
-;; Note that this is a binding to a quoted functional form; this will not
-;; execute on the JVM, but will be executed by SCI over in the browser.
-;;
-;; Every time the incoming `value` changes, mathbox-react will redraw the full
-;; scene.
-
-(def fn-render-fn
-  (q
-   (fn [{:keys [range scale samples f]}]
-     (nextjournal.clerk.viewer/html
-      [mathbox/MathBox
-       {:container {:style {:height "400px" :width "100%"}}
-        :renderer  {:background-color 0xffffff}}
-       [mb/Camera {:proxy true :position [2.3 1 2]}]
-       [mb/Cartesian {:range range :scale scale}
-        [mb/Axis {:axis 1 :width 3}]
-        [mb/Axis {:axis 2 :width 3}]
-        [mb/Axis {:axis 3 :width 3}]
-        [demo.mathbox/Function1 {:samples samples :f f}]]]))))
-
-;; [[fn-render-fn]] also uses some reagent state internally; this is how it's
-;; able to compare current and previous values and decide whether or not to
-;; re-render.
-
-;; The final viewer is a clojure map with these two pieces supplied:
-
-(def fn-viewer
-  {:transform-fn (comp clerk/mark-presented
-                       (clerk/update-val
-                        #(update % :f fn-transform)))
-   :render-fn fn-render-fn})
-
-;; ### Demo
-;;
-;; Let's make a function to try!
-
-(defn my-fn [x t]
-  (+ (square (sin x))
-     (square
-      (cos (* t x)))))
-
-;; The function works locally, with numbers or symbols:
-
-[(my-fn 1 2) (my-fn 'x 't)]
-
-;; Then we'll call it with our new viewer:
-
-(clerk/with-viewer fn-viewer
-  {:range [[-6 6] [-1 1] [-1 1]]
-   :scale [6 1 1]
-   :samples 256
-   :f my-fn})
-
-;; We can write a wrapper function to reuse the scene-setting elements:
-
-(defn ->mathbox [f]
-  (clerk/with-viewer fn-viewer
-    {:range [[-6 6] [-1 1] [-1 1]]
-     :scale [6 1 1]
-     :samples 256
-     :f f}))
-
-;; We can then use the above viewer using `with-viewer`:
-
-(->mathbox my-fn)
-
-;; And here's the equation:
-
-^{::clerk/visibility :hide
-  ::clerk/viewer d/multiviewer}
-(my-fn 'x 't)
-
-;; I used Clerk's `:hide` visibility to only show the result.
-
-;; ### Compound Viewer
-;;
-;; Just for fun, we can even reuse the [[literal-viewer]] component to make a
-;; version that can toggle between function and TeX:
-
-(def compound-fn-viewer
-  (d/literal-viewer
-   (fn [{:keys [f args]}]
-     {:TeX     (clerk/tex
-                (->TeX (simplify (apply f args))))
-      :mathbox (->mathbox f)})))
-
-(clerk/with-viewer compound-fn-viewer
-  {:f my-fn
-   :args ['x 't]})
-
-;; PHEW, okay, let's leave it here for now.
-;;
-;; ## Polynomials
-;;
-;; I think this can work out of the box for an Emmy Polynomial. We really should
-;; be pushing these into Mafs...
-
-(def my-poly
-  (let [x (poly/identity 2)]
-    ((+ (- x)
-        (square x)
-        (cube x)))))
-
-^{::clerk/viewer fn-viewer}
-{:range [[-6 6] [-1 1] [-1 1]]
- :scale [6 1 1]
- :samples 256
- :f my-poly}
+(mafs/mafs
+ {:zoom {:min 0.1 :max 2}}
+ (mafs/cartesian)
+ (mafs/of-x ((expt D 3) tanh) {:color :blue}))

--- a/dev/examples/mathbox/quickstart.clj
+++ b/dev/examples/mathbox/quickstart.clj
@@ -1,0 +1,401 @@
+^{:nextjournal.clerk/visibility {:code :hide}}
+(ns examples.mathbox.quickstart
+  #:nextjournal.clerk
+  {:toc true :no-cache true}
+  (:refer-clojure
+   :exclude [+ - * / zero? compare divide numerator denominator
+             infinite? abs ref partial =])
+  (:require [emmy.clerk :as ec]
+            [emmy.env :as e :refer :all]
+            [emmy.mathbox :as box]
+            [nextjournal.clerk :as clerk]))
+
+(ec/install!)
+
+;; ## Your First Scene
+
+;; You create MathBox.cljs scenes by declaring a MathBox component tree, similar
+;; to writing an HTML DOM using a Reagent component tree.
+
+;; To show anything in MathBox, you need to establish four things:
+
+;; 1) A camera that is looking at...
+;; 2) A coordinate system which contains...
+;; 3) Geometrical data represented via...
+;; 4) A choice of shape to draw it as.
+
+;; For this example, we'll build a 2D rectangular view containing an array of
+;; points, drawn as a continuous line.
+
+;; ### Start with the camera
+
+;; The default 3D camera starts out at `[0 0 0]` (i.e. X, Y, Z), right in the
+;; middle of our diagram. +Z goes out of the screen and -Z into the screen.
+
+;; Declare a scene with `mathbox.core/MathBox` (along with some options for the
+;; container).
+;;
+;; Insert a `mathbox.primitives/Camera` component and pull back its `:position`
+;; 3 units to `[0 0 3]`. We also set `:proxy` to true: this allows interactive
+;; camera controls to override our given position.
+
+(box/mathbox
+ {:container
+  {:style {:height "400px" :width "100%"}}}
+ (box/camera
+  {:position [0 0 3]
+   :proxy true}))
+
+;; We now have an empty scene with a loading bar and nothing to look at. Our
+;; MathBox DOM now looks like:
+
+;; ```jsx
+;; <root>
+;;   <camera proxy={true} position={[0, 0, 3]} />
+;; </root>
+;; ```
+
+;; > See [Printing the DOM](#printing-the-dom) below for details on how to
+;; > generate this representation at the console.
+
+;; If you pass a one-argument function via the `:ref` argument to any component,
+;; you'll receive a MathBox selection that points to the `<camera />` element.
+
+;; ### Add a coordinate system
+
+;; Now we're going to set up a simple 2D cartesian coordinate system. We'll make
+;; it twice as wide as high.
+
+(box/mathbox
+ {:container {:style {:height "400px" :width "100%"}}}
+ (box/camera
+  {:position [0 0 3] :proxy true})
+ (box/cartesian
+  {:range [[-2 2] [-1 1]]
+   :scale [2 1]}))
+
+;; The `:range` specifies the area we're looking at as a vector of pairs: `[-2
+;; 2]` in the `X` direction, `[-1, 1]` in the `Y` direction.
+
+;; The `scale` specifies the projected size of the view, in this case `[2 1]`,
+;; i.e. 2 `X` units and 1 `Y` unit.
+
+;; Add two axes and a grid as children of the `mathbox.primitives/Cartesian` component so we can
+;; finally see something:
+
+^{::clerk/width :wide}
+(box/mathbox
+ {:container {:style {:height "400px" :width "100%"}}}
+ (box/camera
+  {:position [0 0 3] :proxy true})
+ (box/cartesian
+  {:range [[-2 2] [-1 1]]
+   :scale [2 1]}
+  (box/axis {:axis 1 :width 3})
+  (box/axis {:axis 2 :width 3})
+  (box/grid {:width 2 :divideX 20 :divideY 10})))
+
+;; You should see gridlines appear in 50% gray, the default color, at the given
+;; widths. The DOM now looks like this:
+
+;; ```jsx
+;; <root>
+;;   <camera proxy={true} position={[0, 0, 3]} />
+;;   <cartesian range={[[-2, 2], [-1, 1]]} scale={[2, 1]}>
+;;     <axis axis={1} width={3} />
+;;     <axis axis={2} width={3} />
+;;     <grid width={2} divideX={20} divideY={10} />
+;;   </cartesian>
+;; </root>
+;; ```
+
+;; You might make your axes black by passing the `:color "black"` attribute:
+
+^{::clerk/width :wide}
+(box/mathbox
+ {:container {:style {:height "400px" :width "100%"}}}
+ (box/camera {:position [0 0 3] :proxy true})
+ (box/cartesian
+  {:range [[-2 2] [-1 1]] :scale [2 1]}
+
+  (box/axis {:axis 1 :width 3 :color "black"})
+  (box/axis {:axis 2 :width 3 :color "black"})
+  (box/grid {:width 2 :divideX 20 :divideY 10})))
+
+;; As the on-screen size of elements depends on the position of the camera, we
+;; can calibrate our units by setting the `focus` on the `<root>` to match the
+;; camera distance. Set options on `<root>` by passing them to
+;; `mathbox.core/MathBox`:
+
+^{::clerk/width :wide}
+(box/mathbox
+ {:container {:style {:height "400px" :width "100%"}}
+  :focus 3}
+ (box/camera {:position [0 0 3] :proxy true})
+ (box/cartesian
+  {:range [[-2 2] [-1 1]] :scale [2 1]}
+
+  (box/axis {:axis 1 :width 3 :color "black"})
+  (box/axis {:axis 2 :width 3 :color "black"})
+  (box/grid {:width 2 :divideX 20 :divideY 10})))
+
+;; Which gives us:
+
+;; ```jsx
+;; <root focus={3}>
+;;   <camera proxy={true} position={[0, 0, 3]} />
+;;   <cartesian range={[[-2, 2], [-1, 1]]} scale={[2, 1]}>
+;;     <axis axis={1} width={3} color="black" />
+;;     <axis axis={2} width={3} color="black" />
+;;     <grid width={2} divideX={20} divideY={10} />
+;;   </cartesian>
+;; </root>
+;; ```
+
+;; ### Add some data and draw it
+
+;; Now we'll draw a moving sine wave. First we create an `mathbox.primitives/Interval`. This is
+;; a 1D array, sampled over the cartesian view's range. It contains an `:expr`,
+;; an expression to generate the data points.
+
+;; We [make a new
+;; component](https://github.com/reagent-project/reagent/blob/master/doc/CreatingReagentComponents.md)
+;; that generates 64 points, each with two `:channels`, i.e. `X` and `Y` values.
+;; This value sets the number of items that are emitted with each call to
+;; `emit`.
+
+(def data
+  (box/interval
+   {:expr '(fn [emit x _i t]
+             (emit x (Math/sin (+ x t))))
+    :width 64
+    :channels 2}))
+
+;; Here, `x` is the sampled X coordinate, `_i` is the array index (0-63), and
+;; `t` is clock time in seconds, starting from 0. The use of `emit` is similar
+;; to `return`ing a value. It is used to allow multiple values to be emitted
+;; very efficiently.
+
+;; Once we have the data, we can draw it, by [creating a new
+;; component](https://github.com/reagent-project/reagent/blob/master/doc/CreatingReagentComponents.md)
+;; called `Curve` that adds on an `mathbox.primitives/Line`. The target of the line is, by
+;; default, the previous entry in the component tree.
+;;
+;; > Note the use of [React fragments](https://reactjs.org/docs/fragments.html)
+;; here; we can bundle up many components by putting them into a vector starting
+;; with `:<>`.
+
+(def curve
+  [:<>
+   data
+   (box/line {:width 5 :color "#3090FF"})])
+
+;; Note that we've used an HTML hex color instead of a named color. CSS syntax
+;; like `"rgb(255,128,53)"` works too.
+
+;; Add a `Curve` instance to the component tree:
+
+^{::clerk/width :wide}
+(box/mathbox
+ {:container {:style {:height "400px" :width "100%"}}
+  :focus 3}
+ (box/camera {:position [0 0 3] :proxy true})
+ (box/cartesian
+  {:range [[-2 2] [-1 1]] :scale [2 1]}
+
+  (box/axis {:axis 1 :width 3 :color "black"})
+  (box/axis {:axis 2 :width 3 :color "black"})
+  (box/grid {:width 2 :divideX 20 :divideY 10})
+  curve))
+
+;; The DOM now looks like:
+
+;; ```jsx
+;; <root focus={3}>
+;;   <camera proxy={true} position={[0, 0, 3]} />
+;;   <cartesian range={[[-2, 2], [-1, 1]]} scale={[2, 1]}>
+;;     <axis axis={1} width={3} color="black" />
+;;     <axis axis={2} width={3} color="black" />
+;;     <grid width={2} divideX={20} divideY={10} />
+;;     <interval expr={(emit, x, i, t) => {
+;;           emit(x, Math.sin(x + t));
+;;         }} width={64} channels={2} />
+;;     <line width={5} color="#3090FF" />
+;;   </cartesian>
+;; </root>
+;; ```
+
+;; ### Add more shapes
+
+;; The nice thing about separating data from shape is that you can draw the same
+;; data multiple ways. For example, add on an `mathbox.primitives/Point` component to draw
+;; points as well along them length of the data interval:
+
+^{::clerk/width :wide}
+(box/mathbox
+ {:container {:style {:height "400px" :width "100%"}}
+  :focus 3}
+ (box/camera {:position [0 0 3] :proxy true})
+ (box/cartesian
+  {:range [[-2 2] [-1 1]] :scale [2 1]}
+
+  (box/axis {:axis 1 :width 3 :color "black"})
+  (box/axis {:axis 2 :width 3 :color "black"})
+  (box/grid {:width 2 :divideX 20 :divideY 10})
+  curve
+  (box/point {:size 8 :color "#3090FF"})))
+
+;; The different shapes available are documented in
+;; the [`mathbox.primitives.draw`
+;; namespace](https://cljdoc.org/d/org.mentat/mathbox.cljs/CURRENT/api/mathbox.primitives.draw)
+;; Points, lines and surfaces are pretty obvious and do what they say on the
+;; tin. e.g. Fill a 2D `mathbox.primitives/Area` with data and pass it to a `mathbox.primitives/Surface` to draw
+;; a solid triangle mesh.
+
+;; For vectors, faces and strips, the situation changes. To draw 64 vectors as
+;; arrows, you need 128 points: a start and end for each. Thus the data has to
+;; change. We set `items` to 2 and emit two points per iteration. We also add on
+;; a green `mathbox.primitives/Vector` to draw the data:
+
+(def Vector
+  [:<>
+   (box/interval
+    {:expr '(fn [emit x _i t]
+              (emit x 0)
+              (emit x (- (Math/sin (+ x t)))))
+     :width 64
+     :channels 2
+     :items 2})
+   (box/vector
+    {:end true
+     :width 5
+     :color "#50A000"})])
+
+;; > As an alternative to `:expr`, you can also supply an array of `:data`,
+;; > either constant or changing, flat or nested. MathBox will iterate over it
+;; > and emit it for you, picking up any live data. If your data does not
+;; > change, you can set `:live false` to optimize.
+
+;; Render the scene again after adding the new `Vector` component to the end:
+
+^{::clerk/width :wide}
+(box/mathbox
+ {:container {:style {:height "400px" :width "100%"}}
+  :focus 3}
+ (box/camera {:position [0 0 3] :proxy true})
+ (box/cartesian
+  {:range [[-2 2] [-1 1]] :scale [2 1]}
+
+  (box/axis {:axis 1 :width 3 :color "black"})
+  (box/axis {:axis 2 :width 3 :color "black"})
+  (box/grid {:width 2 :divideX 20 :divideY 10})
+
+  curve
+  (box/point {:size 8 :color "#3090FF"})
+
+  Vector))
+
+;; ### Add some floating labels
+
+;; Finally we'll label our coordinate system. First we need to establish a
+;; `mathbox.primitives/Scale`, which will divide our view into nice intervals.
+
+;; ```clj
+;; (box/scale {:divide 10})
+;; ```
+
+;; We can draw our scale as tick marks with `mathbox.primitives/Ticks`:
+
+;; ```clj
+;; (box/ticks {:width 5 :size 15 :color "black"})
+;; ```
+
+;; Now we need to format our numbers into rasterized text:
+
+;; ```clj
+;; (box/format {:digits 2 :weight "bold"})
+;; ```
+
+;; And finally draw the text as floating labels:
+
+;; ```clj
+;; (box/label {:color "red" :zIndex 1})
+;; ```
+
+;; Adding all of these components yields the following scene:
+
+^{::clerk/width :wide}
+(box/mathbox
+ {:container {:style {:height "400px" :width "100%"}}
+  :focus 3}
+ (box/camera {:position [0 0 3] :proxy true})
+ (box/cartesian
+  {:range [[-2 2] [-1 1]]
+   :scale [2 1]}
+
+  (box/axis {:axis 1 :width 3 :color "black"})
+  (box/axis {:axis 2 :width 3 :color "black"})
+  (box/grid {:width 2 :divideX 20 :divideY 10})
+
+  curve
+  (box/point {:size 8 :color "#3090FF"})
+  Vector
+
+  (box/scale {:divide 10})
+  (box/ticks {:width 5 :size 15 :color "black"})
+  (box/format {:digits 2 :weight "bold"})
+  (box/label {:color "red"
+              :zIndex 1})))
+
+;; Here we apply `:zIndex` similar to CSS to ensure the labels overlap in 2D
+;; rather than being placed in 3D. It specifies a layer index, with 0 being the
+;; default, and layers `1...n` stacking on top. Negative `:zIndex` is not
+;; allowed.
+
+;; > Unlike CSS, large `:zIndex` values are not recommended, as the higher the
+;; > `:zIndex` the less depth resolution you have.
+
+;; ### Make it move
+
+;; Finally we'll add on a little bit of animation by adding a `mathbox.primitives/Play` block.
+
+^{::clerk/width :wide}
+(box/mathbox
+ {:container {:style {:height "400px" :width "100%"}}
+  :focus 3}
+ (box/camera {:position [0 0 3] :proxy true})
+ (box/cartesian
+  {:range [[-2 2] [-1 1]]
+   :scale [2 1]}
+
+  (box/axis {:axis 1 :width 3 :color "black"})
+  (box/axis {:axis 2 :width 3 :color "black"})
+  (box/grid {:width 2 :divideX 20 :divideY 10})
+
+  curve
+  (box/point {:size 8 :color "#3090FF"})
+
+  Vector
+
+  (box/scale {:divide 10})
+  (box/ticks {:width 5 :size 15 :color "black"})
+  (box/format {:digits 2 :weight "bold"})
+  (box/label {:color "red"
+              :zIndex 1})
+
+  (box/play
+   {:target "cartesian"
+    :pace 5
+    :to 2
+    :loop true
+    :script
+    [{:props {:range [[-2 2] [-1 1]]}}
+     {:props {:range [[-4 4] [-2 2]]}}
+     {:props {:range [[-2 2] [-1 1]]}}]})))
+
+;; Here `:script` defines the keyframes we'll be animating through. We specify
+;; `:props` will change, namely the `:range`. We pass in the keyframes as an
+;; array, which will assign them to evenly spaced keyframes `(0, 1, 2)`.
+
+;; We set the `:pace` of the animation to 5 seconds per step, tell it to play
+;; till keyframe time `2` and to `:loop` afterwards.

--- a/dev/examples/number.clj
+++ b/dev/examples/number.clj
@@ -1,8 +1,13 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.number
-  (:require [nextjournal.clerk :as clerk]))
+  #:nextjournal.clerk
+  {:toc true}
+  (:require [emmy.clerk :as ec]
+            [emmy.mafs :as mafs]
+            [nextjournal.clerk :as clerk]))
+
+^{::clerk/visibility {:code :hide :result :hide}}
+(ec/install!)
 
 ;; ## Numbers
 
@@ -16,63 +21,39 @@
 
 ;; ### Number Line
 
-(def n-viewer
-  {:transform-fn
-   (comp
-    clerk/mark-presented
-    (clerk/update-val
-     (fn lp [x]
-       (cond (instance? clojure.lang.IDeref x) (lp @x)
-             (vector? x) x
-             (map? x) (vals x)
-             :else [x]))))
-   :render-fn
-   '(fn [xs]
-      [mafs.core/Mafs
-       {:view-box
-        {:x [(min -2 (- (apply min xs) 2))
-             (max 2 (+ (apply max xs) 2))]
-         :y [-0.25 0.25]}}
-       [mafs.coordinates/Cartesian]
-       (for [x xs]
-         [mafs.core/Point
-          {:key x :x x :y 0}])])})
+(defn view-n [x]
+  (let [xs (cond (vector? x) x
+                 (map? x)   (vals x)
+                 :else      [x])]
+    (apply mafs/mafs
+           {:view-box
+            {:x [(min -2 (- (apply min xs) 2))
+                 (max 2 (+ (apply max xs) 2))]
+             :y [-0.25 0.25]}}
+           (mafs/cartesian)
+           (for [x xs]
+             (mafs/point [x 0] {:key x})))))
 
 ;; Here are some individual numbers:
 
 ^{::clerk/width :wide}
-(clerk/with-viewer n-viewer
-  10)
+(view-n 10)
 
 ^{::clerk/width :wide}
-(clerk/with-viewer n-viewer
-  1)
-
-;; We can't put metadata directly on numbers, so here's a better way.
-
-#_{:clj-kondo/ignore [:redundant-do]}
-^{::clerk/width :wide
-  ::clerk/viewer n-viewer}
-(do -3)
+(view-n 1)
 
 ;; Collections of numbers:
 
-^{::clerk/width :wide
-  ::clerk/viewer n-viewer}
-[10 1 -3]
+^{::clerk/width :wide}
+(view-n [10 1 -3])
 
+;; maps:
 
-;; ### Stateful Example
-
-^{::clerk/sync true
-  ::clerk/viewer n-viewer}
-(defonce !numbers
-  (atom
-   {:x 10
-    :y 1
-    :z -3}))
-
-@!numbers
+^{::clerk/width :wide}
+(view-n
+ {:x 10
+  :y 1
+  :z -3})
 
 ;; ## Notes:
 ;;

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -25,10 +25,10 @@
   {:index index
    :browse? true
    :watch-paths ["src" "dev"]
-   :custom-js ec/custom-js
+   ;; :custom-js ec/custom-js
 
    ;; Enable this and disable `:custom-js` to build new custom components.
-   ;; :cljs-namespaces '[emmy-viewers.sci-extensions]
+   :cljs-namespaces '[emmy-viewers.sci-extensions]
    })
 
 (def static-defaults

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "shadow-cljs": "2.23.1",
-        "three": "0.153.0",
+        "three": "0.149.0",
         "threestrap": "0.5.1",
         "use-sync-external-store": "1.2.0",
         "vh-sticky-table-header": "1.2.1",
@@ -2635,9 +2635,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.153.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.153.0.tgz",
-      "integrity": "sha512-OCP2/uQR6GcDpSLnJt/3a4mdS0kNWcbfUXIwLoEMgLzEUIVIYsSDwskpmOii/AkDM+BBwrl6+CKgrjX9+E2aWg=="
+      "version": "0.149.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.149.0.tgz",
+      "integrity": "sha512-tohpUxPDht0qExRLDTM8sjRLc5d9STURNrdnK3w9A+V4pxaTBfKWWT/IqtiLfg23Vfc3Z+ImNfvRw1/0CtxrkQ=="
     },
     "node_modules/threestrap": {
       "version": "0.5.1",
@@ -5040,9 +5040,9 @@
       }
     },
     "three": {
-      "version": "0.153.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.153.0.tgz",
-      "integrity": "sha512-OCP2/uQR6GcDpSLnJt/3a4mdS0kNWcbfUXIwLoEMgLzEUIVIYsSDwskpmOii/AkDM+BBwrl6+CKgrjX9+E2aWg=="
+      "version": "0.149.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.149.0.tgz",
+      "integrity": "sha512-tohpUxPDht0qExRLDTM8sjRLc5d9STURNrdnK3w9A+V4pxaTBfKWWT/IqtiLfg23Vfc3Z+ImNfvRw1/0CtxrkQ=="
     },
     "threestrap": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "shadow-cljs": "2.23.1",
-    "three": "0.153.0",
+    "three": "0.149.0",
     "threestrap": "0.5.1",
     "use-sync-external-store": "1.2.0",
     "vh-sticky-table-header": "1.2.1",

--- a/src/emmy/mafs/plot.clj
+++ b/src/emmy/mafs/plot.clj
@@ -2,8 +2,8 @@
   "Server-side rendering functions for the components declared in the
   [`mafs.plot`](https://cljdoc.org/d/org.mentat/mafs.cljs/CURRENT/api/mafs.plot)
   namespace of the [`Mafs.cljs` project](https://mafs.mentat.org)."
-  (:require [emmy.mafs.compile :as c]
-            [emmy.mafs.core :as mafs]))
+  (:require [emmy.mafs.core :as mafs]
+            [emmy.viewer.compile :as c]))
 
 (defn of-x
   "Takes either
@@ -293,6 +293,7 @@
    (if (c/opts? f-or-opts)
      (let [[xy-bind opts] (c/compile-2d f-or-opts :xy)
            [op-bind opts] (c/compile-2d opts :xy-opacity)]
-       (c/wrap [xy-bind op-bind]
-               ['mafs.plot/VectorField opts]))
+       (mafs/fragment
+        (c/wrap [xy-bind op-bind]
+                ['mafs.plot/VectorField opts])))
      (vector-field f-or-opts {}))))

--- a/src/emmy/viewer.clj
+++ b/src/emmy/viewer.clj
@@ -151,7 +151,7 @@
 ;; ### Parameterized Functions
 ;;
 ;; This section defines supporting types and the [[with-params]] constructor.
-;; This code is used by namespaces like [[emmy.mafs.compile]] to construct a
+;; This code is used by namespaces like [[emmy.viewer.compile]] to construct a
 ;; form that compiles a parametric function via Emmy, and then wraps that in an
 ;; outer function that fetches the parameters out of an atom on each call.
 

--- a/src/emmy/viewer/compile.clj
+++ b/src/emmy/viewer/compile.clj
@@ -1,0 +1,147 @@
+(ns ^:no-doc emmy.viewer.compile
+  "This namespace contains functions for compiling Emmy function objects down to
+  JavaScript `js/Function` constructor calls.
+
+  See [[emmy.mafs.plot]] for example uses."
+  (:require [emmy.expression.compile :as xc]
+            [emmy.structure :as s]
+            [emmy.viewer :as v]))
+
+(defn compile?
+  "Returns true if `f` is an argument that should be compiled by Emmy, false
+  otherwise.
+
+  NOTE that this predicate is quite permissive. Anything that does NOT pass this
+  test will be treated as a quoted form that `Mafs.cljs` knows how to do
+  something with."
+  [f]
+  (or (v/param-f? f)
+      (and (ifn? f)
+           (not (symbol? f)))))
+
+(defn opts?
+  "Returns true for actual maps of options (vs [[emmy.viewer/param-f?]]-true
+  instances, which are map-like but NOT meant to be treated as options), false
+  otherwise."
+  [m]
+  (and (map? m)
+       (not (v/param-f? m))))
+
+;; ## Compile Functions
+
+(defn param-1d
+  "Takes:
+
+  - `sym`, a symbol that the compiled function will be bound to
+  - a [[emmy.viewer/ParamF]] map with an `f` of one Double argument
+
+  and returns a pair of
+
+  - a function body of the form `(js/Function. ...)`
+  - the NEW quoted form that should be passed along to Mafs.
+
+  See the body of [[compile-1d]] for more details."
+  [sym {:keys [f params atom]}]
+  [(xc/compile-state-fn
+    (fn [& params]
+      (let [inner (apply f params)]
+        (fn [[x]] (inner x))))
+    params
+    [0]
+    {:mode :js})
+   `(let [psym# (mapv @~atom ~params)]
+      (fn [x#]
+        (~sym [x#] psym#)))])
+
+(defn compile-1d
+  "Takes
+
+  - an options map `opts` supplied to some Mafs component
+  - the `k` that maps to the function (of one Double argument) to compile
+
+  and returns a pair of
+
+  - a sequence of new bindings
+  - the options map updated to reference the new compiled fn via symbol."
+  [opts k]
+  (let [v (get opts k)]
+    (if-not (compile? v)
+      [[] opts]
+      (let [sym          (gensym)
+            v            (if (vector? v) (s/vector->up v) v)
+            [body new-f] (if (v/param-f? v)
+                           (param-1d sym v)
+                           [(xc/compile-fn v 1 {:mode :js}) sym])]
+        [[sym (list* 'js/Function. body)]
+         (assoc opts k new-f)]))))
+
+(defn param-2d
+  "Takes:
+
+  - `sym`, a symbol that the compiled function will be bound to
+  - a [[emmy.viewer/ParamF]] map with an `f` of one `[double double]`-shaped
+    argument
+
+  and returns a pair of
+
+  - a function body of the form `(js/Function. ...)`
+  - the NEW quoted form that should be passed along to Mafs.
+
+  See the body of [[compile-2d]] for more details."
+  [sym {:keys [f params atom]}]
+  [(xc/compile-state-fn f params [0 0] {:mode :js})
+   `(let [psym# (mapv @~atom ~params)]
+      (fn [xy#]
+        (~sym xy# psym#)))])
+
+(defn compile-2d
+  "Takes
+
+  - an options map `opts` supplied to some Mafs component
+  - the `k` that maps to the function (of one `[double double]`-shaped argument)
+    to compile
+
+  and returns a pair of
+
+  - a sequence of new bindings
+  - the options map updated to reference the new compiled fn via symbol."
+  [opts k]
+  (let [v (get opts k)]
+    (if-not (compile? v)
+      [[] opts]
+      (let [sym          (gensym)
+            v            (if (vector? v) (s/vector->up v) v)
+            [body new-f] (if (v/param-f? v)
+                           (param-2d sym v)
+                           [(xc/compile-state-fn v false [0 0] {:mode :js}) sym])]
+        [[sym (list* 'js/Function. body)]
+         (assoc opts k new-f)]))))
+
+(defn wrap
+  "Given a sequence of pairs of `bindings` and a body, returns a
+  `reagent.core/with-let` binding form.
+
+  For example:
+
+  ```clojure
+  (wrap [['a \"face\"] ['b \"cake\"]] '(+ a b))
+  ;;=> (reagent.core/with-let [a \"face\" b \"cake\"] (+ a b))
+  ```
+  "[bindings body]
+  (let [bindings (into [] cat bindings)]
+    (if (seq bindings)
+      (list 'reagent.core/with-let bindings body)
+      body)))
+
+(defn compile-vals
+  "Takes a map `m` of key => val and tries to compile all values using
+  `compile-fn` (either [[compile-1d]] or [[compile-2d]]).
+
+  returns a pair of [<all bindings>, <new map>]."
+  [m compile-fn]
+  (reduce
+   (fn [[bindings opts] k]
+     (let [[v opts] (compile-fn opts k)]
+       [(conj bindings v) opts]))
+   [[] m]
+   (keys m)))


### PR DESCRIPTION
- #39:

  - moves `emmy.mafs.compile` to `emmy.viewer.compile`, for future use by
    MathBox.

  - ports examples over the new style with `emmy.clerk` and friends.