### PR TITLE
ode-curve and supporting code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [unreleased]
 
+- #44:
+
+  - Adds `emmy.viewer.physics` and `emmy.mathbox.physics` in support of the new
+    `emmy.mathbox.physics/ode-curve` function, similar to `parametric-curve` but
+    powered by a derivative function and initial state. See the new
+    [ode](https://emmy-viewers.mentat.org/dev/examples/mathbox/ode) example page
+    for a demo.
+
+  - Adds a new Lorenz attractor example at `examples.mathbox.ode`.
+
+  - Adds `emmy.clerk/{build!,serve!,halt!}` to make it more straightforward to
+    configure Clerk with our custom JS bundle.
+
+  - Adds a var-arg `viewers` argument for other viewers to
+    `emmy.clerk/install!`.
+
+  - Adds `emmy.viewer.stopwatch` with a client and server-side stopwatch
+    component; this is currently alpha, but will be used for running physics
+    animations.
+
+  - Migrates `examples.simulation.toroid` to full server-side style with no more
+    custom viewer.
+
 - #32 updates the `emmy-viewers/clerk` template to use the new pre-compiled
   bundle and all of the good stuff in it.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# Emmy-viewers
+# Emmy-Viewers
 
-A library of [Clerk][clerk-url] viewers and [Reagent][reagent-url] components
-designed for visual representation and exploration of mathematical objects in
-the [Emmy][emmy-url] computer algebra system.
+A library of functions for building high-performance interactive 2D and 3D
+mathematical scenes powered by the [Emmy][emmy-url] computer algebra system.
+
+Emmy-Viewers makes it easy to use either [Clerk][clerk-url] or
+[Portal][portal-url]
 
 <div align="center">
 
@@ -14,16 +16,9 @@ the [Emmy][emmy-url] computer algebra system.
 
 </div>
 
-These viewers are built on the following libraries:
+## Quickstart with Clerk
 
-- [MathBox.cljs][mathbox-url]
-- [JSXGraph.cljs][jsxgraph-url]
-- [Mafs.cljs][mafs-url]
-- [Leva.cljs][leva-url]
-
-## Quickstart
-
-Install `emmy-viewers` into your ClojureScript project using the instructions at
+Install `emmy-viewers` into your Clojure project using the instructions at
 its Clojars page:
 
 [![Clojars Project][clojars]][clojars-url]
@@ -31,15 +26,48 @@ its Clojars page:
 Or grab the most recent code using a Git dependency:
 
 ```clj
-;; deps
+;; replace $GIT_SHA with the sha you'd like to target!
+
 {io.github.mentat-collective/emmy-viewers
-  {:git/sha "$GIT_SHA"}}
+  {:git/url "https://github.com/mentat-collective/emmy-viewers.git"
+  :git/sha "$GIT_SHA"}}
 ```
 
-The project is currently in alpha stage, so you'll have to do your own
-source-code reading to figure out what's available. See the [demo
-directory][emmy-viewers-url] for examples and inspiration, then go read the
-associated code for each notebook linked at the top of its page.
+Then install Clerk: [![Clojars Project][clerk-clojars]][clerk-clojars-url]
+
+Create a namespace called `emmy.demo`, and install our default Clerk viewers
+from `emmy.clerk`:
+
+```clojure
+(ns emmy.demo
+  (:refer-clojure
+   :exclude [+ - * / zero? compare divide numerator denominator
+             infinite? abs ref partial =])
+  (:require [emmy.clerk :as ec]
+            [emmy.env :as e :refer :all]
+            [emmy.mafs :as mafs]
+            [emmy.mathbox.plot :as plot]
+            [emmy.viewer :as ev]
+            [nextjournal.clerk :as clerk]))
+
+^{::clerk/visibility {:code :hide :result :hide}}
+(ec/install!)
+```
+
+Add this line to the file to plot a function using the [Mafs][mafs-url]:
+
+```clojure
+(mafs/of-x sin {:color :blue})
+```
+
+Render it by calling `(nextjournal.clerk/show! "src/emmy/demo.clj")` at the
+REPL. You'll see the following:
+
+;; TODO insert picture, add more getting started info with a MathBox example.
+
+## Quickstart with Portal
+
+;; TODO fill in.
 
 ## Demo Instructions
 
@@ -67,6 +95,13 @@ This will open a browser window to `http://localhost:7777` with the contents of
 the documentation notebook. Any edits you make to any file in the `src` or `dev`
 directories will be picked up and displayed in the browser on save.
 
+These viewers are built on the following libraries:
+
+- [MathBox.cljs][mathbox-url]
+- [JSXGraph.cljs][jsxgraph-url]
+- [Mafs.cljs][mafs-url]
+- [Leva.cljs][leva-url]
+
 ## Thanks and Support
 
 To support this work and my other open source projects, consider sponsoring me
@@ -81,23 +116,26 @@ Distributed under the [MIT License](LICENSE). See [LICENSE](LICENSE).
 
 [build-status-url]: https://github.com/mentat-collective/emmy-viewers/actions/workflows/kondo.yml
 [build-status]: https://github.com/mentat-collective/emmy-viewers/actions/workflows/kondo.yml/badge.svg?branch=main
+[clerk-clojars-url]: https://clojars.org/io.github.nextjournal/clerk
+[clerk-clojars]: https://img.shields.io/clojars/v/io.github.nextjournal/clerk.svg
+[clerk-url]: https://github.com/nextjournal/clerk
 [cljdoc-url]: https://cljdoc.org/d/org.mentat/emmy-viewers/CURRENT
 [cljdoc]: https://cljdoc.org/badge/org.mentat/emmy-viewers
 [clojars-url]: https://clojars.org/org.mentat/emmy-viewers
 [clojars]: https://img.shields.io/clojars/v/org.mentat/emmy-viewers.svg
 [discord-url]: https://discord.gg/hsRBqGEeQ4
 [discord]: https://img.shields.io/discord/731131562002743336?style=flat&colorA=000000&colorB=000000&label=&logo=discord
-[license-url]: LICENSE
-[license]: https://img.shields.io/badge/license-MIT-brightgreen.svg
-[mentat-slack-url]: https://clojurians.slack.com/archives/C041G9B1AAK
-[github-url]: https://github.com/mentat-collective/emmy-viewers
-[reagent-url]: https://reagent-project.github.io/
-[clerk-url]: https://github.com/nextjournal/clerk
 [emmy-url]: https://github.com/mentat-collective/emmy
 [emmy-viewers-url]: https://emmy-viewers.mentat.org
-[mathbox-url]: https://mathbox.mentat.org
-[mafs-url]: https://mafs.mentat.org
+[fdg-url]: http://mitpress.mit.edu/books/functional-differential-geometry
+[github-url]: https://github.com/mentat-collective/emmy-viewers
 [jsxgraph-url]: https://jsxgraph.mentat.org
 [leva-url]: https://leva.mentat.org
+[license-url]: LICENSE
+[license]: https://img.shields.io/badge/license-MIT-brightgreen.svg
+[mafs-url]: https://mafs.mentat.org
+[mathbox-url]: https://mathbox.mentat.org
+[mentat-slack-url]: https://clojurians.slack.com/archives/C041G9B1AAK
+[portal-url]: https://github.com/djblue/portal
+[reagent-url]: https://reagent-project.github.io/
 [sicm-url]: http://mitpress.mit.edu/books/structure-and-interpretation-classical-mechanics
-[fdg-url]: http://mitpress.mit.edu/books/functional-differential-geometry

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ This will open a browser window to `http://localhost:7777` with the contents of
 the documentation notebook. Any edits you make to any file in the `src` or `dev`
 directories will be picked up and displayed in the browser on save.
 
+## Dependencies
+
 These viewers are built on the following libraries:
 
 - [MathBox.cljs][mathbox-url]

--- a/dev/examples/complex.clj
+++ b/dev/examples/complex.clj
@@ -1,7 +1,6 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
-(ns examples.complex)
+^{:nextjournal.clerk/visibility {:code :hide}}
+(ns examples.complex
+  {:nextjournal.clerk/toc true})
 
 ;; ## Complex Numbers
 ;;

--- a/dev/examples/continued_fractions.clj
+++ b/dev/examples/continued_fractions.clj
@@ -1,7 +1,6 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.continued-fractions
+  {:nextjournal.clerk/toc true}
   (:require [emmy.generic :as g]
             [emmy.ratio :as r]))
 

--- a/dev/examples/expression.clj
+++ b/dev/examples/expression.clj
@@ -1,6 +1,6 @@
 ^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.expression
-  #:nextjournal.clerk {:toc true}
+  {:nextjournal.clerk/toc true}
   (:refer-clojure
    :exclude [+ - * / = zero? compare numerator denominator ref partial])
   (:require [nextjournal.clerk :as clerk]

--- a/dev/examples/functions.clj
+++ b/dev/examples/functions.clj
@@ -1,6 +1,6 @@
 ^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.functions
-  #:nextjournal.clerk{:toc true}
+  {:nextjournal.clerk/toc true}
   (:refer-clojure
    :exclude [+ - * / = zero? compare numerator denominator ref partial
              infinite? abs])

--- a/dev/examples/mafs.clj
+++ b/dev/examples/mafs.clj
@@ -1,7 +1,6 @@
 ^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.mafs
-  #:nextjournal.clerk
-  {:toc true}
+  {:nextjournal.clerk/toc true}
   (:refer-clojure
    :exclude [+ - * / zero? compare divide numerator denominator
              infinite? abs ref partial =])

--- a/dev/examples/mathbox/ode.clj
+++ b/dev/examples/mathbox/ode.clj
@@ -7,8 +7,8 @@
   (:require [emmy.clerk :as ec]
             [emmy.leva :as leva]
             [emmy.env :as e :refer :all]
-            [emmy.expression.compile :as xc]
             [emmy.viewer :as ev]
+            [emmy.mathbox.physics :as ph]
             [emmy.mathbox.plot :as p]))
 
 {:nextjournal.clerk/width :full}
@@ -17,24 +17,6 @@
 (ec/install!)
 
 ;; ## ODE Solver
-(def fn-body
-  ["a0008" "a0009" "a0010" "  const y0001 = a0008[0];\n  const y0002 = a0008[1];\n  const y0003 = a0008[2];\n  const y0004 = a0008[3];\n  const y0005 = a0008[4];\n  const p0006 = a0010[0];\n  const p0007 = a0010[1];\n  const _0011 = Math.sin(y0002);\n  const _0012 = Math.pow(y0005, 2.0);\n  const _0013 = Math.cos(y0002);\n  a0009[0] = 1.0;\n  a0009[1] = y0004;\n  a0009[2] = y0005;\n  a0009[3] = (- p0007 * _0012 * _0013 * _0011 - p0006 * _0012 * _0011) / p0007;\n  a0009[4] = (2.0 * p0007 * y0004 * y0005 * _0011) / (p0007 * _0013 + p0006);"])
-
-(def xform-body
-  ["a0008" "a0009" "a0010" "  const y0001 = a0008[0];\n  const y0002 = a0008[1];\n  const y0003 = a0008[2];\n  const y0004 = a0008[3];\n  const y0005 = a0008[4];\n  const p0006 = a0010[0];\n  const p0007 = a0010[1];\n  const _0011 = Math.cos(y0002);\n  const _0012 = Math.sin(y0003);\n  const _0013 = Math.cos(y0003);\n  a0009[0] = p0007 * _0011 * _0013 + p0006 * _0013;\n  a0009[1] = p0007 * _0011 * _0012 + p0006 * _0012;\n  a0009[2] = p0007 * Math.sin(y0002);"])
-
-
-(let [params (list 'js/Array. 2 0.5)]
-  (p/scene
-   ['emmy.mathbox.physics/ODECurve
-    {:steps       8000
-     :f'          `(reagent.core/with-let [sym# ~(list* 'js/Function. fn-body)]
-                     (fn [in# out#]
-                       (sym# in# out# ~params)))
-     :state->xyz `(reagent.core/with-let [sym# ~(list* 'js/Function. xform-body)]
-                    (fn [in# out#]
-                      (sym# in# out# ~params)))
-     :initial-state [0 0 0 '(Math/cos 0.44) '(Math/sin 0.44)]}]))
 
 (defn lorenz
   "https://en.wikipedia.org/wiki/Lorenz_system"
@@ -46,54 +28,24 @@
 
 (ev/with-let [!params {:sigma 10 :rho 28 :beta 2.667
                        :steps 5000}]
-  (let [f       lorenz
-        fn-body (xc/compile-state-fn
-                 f [0 0 0] [0 0 0]
-                 {:mode :js
-                  :simplify? true
-                  :calling-convention :primitive})]
-
-    (p/scene
-     {:range [[-10 10] [-10 10] [0 30]]
-      :threestrap {:plugins ["core" "controls" "cursor" "stats"]}
-      :camera [-3 0 0]
-      :axes []
-      :grids []}
-     (leva/controls
-      {:atom !params
-       :schema {:sigma {:min -2 :max 20 :step 0.01}
-                :rho {:min -2 :max 30 :step 0.01}
-                :beta {:min -4 :max 5 :step 0.01}
-                :steps {:min 500 :max 9000 :step 50}}})
-     ['emmy.mathbox.physics/ODECurve
-      {:steps (ev/get !params :steps)
-       :dt 1e-2
-       :width 2
-       :arrow-size 8
-       :end? true
-       :f' `(reagent.core/with-let [sym# ~(list* 'js/Function. fn-body)]
-              (let [psym# (apply ~'array (map @~!params [:sigma :rho :beta]))]
-                (fn [in# out#]
-                  (sym# in# out# psym#))))
-       :initial-state [0 1 1.05]}])))
-
-;; TODO next steps: get it so I can pass a proper f' in!
-
-#_
-[Curve
- {:state-derivative (apply js/Function (:L opts))
-  :state->xyz render-fn
-  :initial-state-fn
-  (fn []
-    (let [st      (.-state !params)
-          alpha_0 (:alpha_0 st)]
-      ;; alpha_0 is the direction of the initial velocity
-      ;; in (theta, phi)-space. Since we're not doing dynamics,
-      ;; the speed doesn't matter, just the direction, so we do
-      ;; it as a unit vector.
-      [0
-       (:theta_0 st)
-       0
-       (Math/cos alpha_0) (Math/sin alpha_0)]))
-  :steps 1500
-  :params !arr}]
+  (p/scene
+   {:range [[-10 10] [-10 10] [0 30]]
+    :threestrap {:plugins ["core" "controls" "cursor" "stats"]}
+    :camera [-3 0 0]
+    :axes []
+    :grids []}
+   (leva/controls
+    {:folder {:name "Lorenz Attractor"}
+     :atom !params
+     :schema {:sigma {:min -2 :max 20 :step 0.01}
+              :rho {:min -2 :max 30 :step 0.01}
+              :beta {:min -4 :max 5 :step 0.01}
+              :steps {:min 500 :max 9000 :step 50}}})
+   (ph/ode-curve
+    {:initial-state [0 1 1.05]
+     :f' (ev/with-params {:atom !params :params [:sigma :rho :beta]}
+           lorenz)
+     :steps (ev/get !params :steps)
+     :dt 1e-2
+     :width 2
+     :end? true})))

--- a/dev/examples/mathbox/ode.clj
+++ b/dev/examples/mathbox/ode.clj
@@ -5,12 +5,13 @@
    :exclude [+ - * / zero? compare divide numerator denominator
              infinite? abs ref partial =])
   (:require [emmy.clerk :as ec]
-            [emmy.leva]
+            [emmy.leva :as leva]
             [emmy.env :as e :refer :all]
+            [emmy.expression.compile :as xc]
             [emmy.viewer :as ev]
             [emmy.mathbox.plot :as p]))
 
-{:nextjournal.clerk/width :wide}
+{:nextjournal.clerk/width :full}
 
 ^{:nextjournal.clerk/visibility {:code :hide :result :hide}}
 (ec/install!)
@@ -23,17 +24,57 @@
   ["a0008" "a0009" "a0010" "  const y0001 = a0008[0];\n  const y0002 = a0008[1];\n  const y0003 = a0008[2];\n  const y0004 = a0008[3];\n  const y0005 = a0008[4];\n  const p0006 = a0010[0];\n  const p0007 = a0010[1];\n  const _0011 = Math.cos(y0002);\n  const _0012 = Math.sin(y0003);\n  const _0013 = Math.cos(y0003);\n  a0009[0] = p0007 * _0011 * _0013 + p0006 * _0013;\n  a0009[1] = p0007 * _0011 * _0012 + p0006 * _0012;\n  a0009[2] = p0007 * Math.sin(y0002);"])
 
 
-(p/scene
- ['emmy.mathbox.physics/Curve
-  {:steps       8000
-   :f'          `(reagent.core/with-let [sym# ~(list* 'js/Function. fn-body)]
-                   (fn [in# out#]
-                     (sym# in# out# ~(list 'js/Array. 2 0.5))))
-   :state->xyz `(reagent.core/with-let [sym# ~(list* 'js/Function. xform-body)]
-                  (fn [in# out#]
-                    (sym# in# out# ~(list 'js/Array. 2 0.5))))
-   :y0 [0 0 0 '(Math/cos 0.44) '(Math/sin 0.44)]}])
+(let [params (list 'js/Array. 2 0.5)]
+  (p/scene
+   ['emmy.mathbox.physics/Curve
+    {:steps       8000
+     :f'          `(reagent.core/with-let [sym# ~(list* 'js/Function. fn-body)]
+                     (fn [in# out#]
+                       (sym# in# out# ~params)))
+     :state->xyz `(reagent.core/with-let [sym# ~(list* 'js/Function. xform-body)]
+                    (fn [in# out#]
+                      (sym# in# out# ~params)))
+     :y0 [0 0 0 '(Math/cos 0.44) '(Math/sin 0.44)]}]))
 
+
+(defn lorenz
+  "https://en.wikipedia.org/wiki/Lorenz_system"
+  [sigma rho beta]
+  (fn [[x y z]]
+    [(* sigma (- y x))
+     (- (* x (- rho z)) y)
+     (- (* x y) (* beta z))]))
+
+(ev/with-let [!params {:sigma 10 :rho 28 :beta 2.667
+                       :steps 5000}]
+  (let [f       lorenz
+        fn-body (xc/compile-state-fn
+                 f [0 0 0] [0 0 0]
+                 {:mode :js
+                  :simplify? true
+                  :calling-convention :primitive})]
+    (p/scene
+     {:range [[-10 10] [-10 10] [0 30]]
+      :threestrap {:plugins ["core" "controls" "cursor" "stats"]}
+      :camera [-3 0 0]
+      :axes []
+      :grids []}
+     (leva/controls
+      {:atom !params
+       :schema {:sigma {:min -2 :max 20 :step 0.01}
+                :rho {:min -2 :max 30 :step 0.01}
+                :beta {:min -4 :max 5 :step 0.01}
+                :steps {:min 500 :max 9000 :step 50}}})
+     ['emmy.mathbox.physics/Curve
+      {:steps (ev/get !params :steps)
+       :dt 1e-2
+       :f' `(reagent.core/with-let [sym# ~(list* 'js/Function. fn-body)]
+              (let [psym# (apply ~'array (map @~!params [:sigma :rho :beta]))]
+                (fn [in# out#]
+                  (sym# in# out# psym#))))
+       :y0 [0 1 1.05]}])))
+
+;; TODO next steps: get it so I can pass a proper f' in!
 
 #_
 [Curve

--- a/dev/examples/mathbox/ode.clj
+++ b/dev/examples/mathbox/ode.clj
@@ -26,7 +26,7 @@
 
 (let [params (list 'js/Array. 2 0.5)]
   (p/scene
-   ['emmy.mathbox.physics/Curve
+   ['emmy.mathbox.physics/ODECurve
     {:steps       8000
      :f'          `(reagent.core/with-let [sym# ~(list* 'js/Function. fn-body)]
                      (fn [in# out#]
@@ -34,8 +34,7 @@
      :state->xyz `(reagent.core/with-let [sym# ~(list* 'js/Function. xform-body)]
                     (fn [in# out#]
                       (sym# in# out# ~params)))
-     :y0 [0 0 0 '(Math/cos 0.44) '(Math/sin 0.44)]}]))
-
+     :initial-state [0 0 0 '(Math/cos 0.44) '(Math/sin 0.44)]}]))
 
 (defn lorenz
   "https://en.wikipedia.org/wiki/Lorenz_system"
@@ -53,6 +52,7 @@
                  {:mode :js
                   :simplify? true
                   :calling-convention :primitive})]
+
     (p/scene
      {:range [[-10 10] [-10 10] [0 30]]
       :threestrap {:plugins ["core" "controls" "cursor" "stats"]}
@@ -65,14 +65,17 @@
                 :rho {:min -2 :max 30 :step 0.01}
                 :beta {:min -4 :max 5 :step 0.01}
                 :steps {:min 500 :max 9000 :step 50}}})
-     ['emmy.mathbox.physics/Curve
+     ['emmy.mathbox.physics/ODECurve
       {:steps (ev/get !params :steps)
        :dt 1e-2
+       :width 2
+       :arrow-size 8
+       :end? true
        :f' `(reagent.core/with-let [sym# ~(list* 'js/Function. fn-body)]
               (let [psym# (apply ~'array (map @~!params [:sigma :rho :beta]))]
                 (fn [in# out#]
                   (sym# in# out# psym#))))
-       :y0 [0 1 1.05]}])))
+       :initial-state [0 1 1.05]}])))
 
 ;; TODO next steps: get it so I can pass a proper f' in!
 

--- a/dev/examples/mathbox/ode.clj
+++ b/dev/examples/mathbox/ode.clj
@@ -1,0 +1,55 @@
+^{:nextjournal.clerk/visibility {:code :hide}}
+(ns examples.mathbox.ode
+  #:nextjournal.clerk{:toc true}
+  (:refer-clojure
+   :exclude [+ - * / zero? compare divide numerator denominator
+             infinite? abs ref partial =])
+  (:require [emmy.clerk :as ec]
+            [emmy.leva]
+            [emmy.env :as e :refer :all]
+            [emmy.viewer :as ev]
+            [emmy.mathbox.plot :as p]))
+
+{:nextjournal.clerk/width :wide}
+
+^{:nextjournal.clerk/visibility {:code :hide :result :hide}}
+(ec/install!)
+
+;; ## ODE Solver
+(def fn-body
+  ["a0008" "a0009" "a0010" "  const y0001 = a0008[0];\n  const y0002 = a0008[1];\n  const y0003 = a0008[2];\n  const y0004 = a0008[3];\n  const y0005 = a0008[4];\n  const p0006 = a0010[0];\n  const p0007 = a0010[1];\n  const _0011 = Math.sin(y0002);\n  const _0012 = Math.pow(y0005, 2.0);\n  const _0013 = Math.cos(y0002);\n  a0009[0] = 1.0;\n  a0009[1] = y0004;\n  a0009[2] = y0005;\n  a0009[3] = (- p0007 * _0012 * _0013 * _0011 - p0006 * _0012 * _0011) / p0007;\n  a0009[4] = (2.0 * p0007 * y0004 * y0005 * _0011) / (p0007 * _0013 + p0006);"])
+
+(def xform-body
+  ["a0008" "a0009" "a0010" "  const y0001 = a0008[0];\n  const y0002 = a0008[1];\n  const y0003 = a0008[2];\n  const y0004 = a0008[3];\n  const y0005 = a0008[4];\n  const p0006 = a0010[0];\n  const p0007 = a0010[1];\n  const _0011 = Math.cos(y0002);\n  const _0012 = Math.sin(y0003);\n  const _0013 = Math.cos(y0003);\n  a0009[0] = p0007 * _0011 * _0013 + p0006 * _0013;\n  a0009[1] = p0007 * _0011 * _0012 + p0006 * _0012;\n  a0009[2] = p0007 * Math.sin(y0002);"])
+
+
+(p/scene
+ ['emmy.mathbox.physics/Curve
+  {:steps       8000
+   :f'          `(reagent.core/with-let [sym# ~(list* 'js/Function. fn-body)]
+                   (fn [in# out#]
+                     (sym# in# out# ~(list 'js/Array. 2 0.5))))
+   :state->xyz `(reagent.core/with-let [sym# ~(list* 'js/Function. xform-body)]
+                  (fn [in# out#]
+                    (sym# in# out# ~(list 'js/Array. 2 0.5))))
+   :y0 [0 0 0 '(Math/cos 0.44) '(Math/sin 0.44)]}])
+
+
+#_
+[Curve
+ {:state-derivative (apply js/Function (:L opts))
+  :state->xyz render-fn
+  :initial-state-fn
+  (fn []
+    (let [st      (.-state !params)
+          alpha_0 (:alpha_0 st)]
+      ;; alpha_0 is the direction of the initial velocity
+      ;; in (theta, phi)-space. Since we're not doing dynamics,
+      ;; the speed doesn't matter, just the direction, so we do
+      ;; it as a unit vector.
+      [0
+       (:theta_0 st)
+       0
+       (Math/cos alpha_0) (Math/sin alpha_0)]))
+  :steps 1500
+  :params !arr}]

--- a/dev/examples/mathbox/ode.clj
+++ b/dev/examples/mathbox/ode.clj
@@ -1,3 +1,4 @@
+
 ^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.mathbox.ode
   {:nextjournal.clerk/toc true}

--- a/dev/examples/mathbox/ode.clj
+++ b/dev/examples/mathbox/ode.clj
@@ -1,6 +1,6 @@
 ^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.mathbox.ode
-  #:nextjournal.clerk{:toc true}
+  {:nextjournal.clerk/toc true}
   (:refer-clojure
    :exclude [+ - * / zero? compare divide numerator denominator
              infinite? abs ref partial =])

--- a/dev/examples/matrix.clj
+++ b/dev/examples/matrix.clj
@@ -1,6 +1,5 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
-(ns examples.matrix)
+^{:nextjournal.clerk/visibility {:code :hide}}
+(ns examples.matrix
+  {:nextjournal.clerk/toc true})
 
 ;; ## Matrices

--- a/dev/examples/modint.clj
+++ b/dev/examples/modint.clj
@@ -1,12 +1,5 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
-(ns examples.modint)
+^{:nextjournal.clerk/visibility {:code :hide}}
+(ns examples.modint
+  {:nextjournal.clerk/toc true})
 
 ;; ## Modular Integers
-
-;; TODO remaining:
-;;
-;; Operator
-;; Structures
-;; Matrix

--- a/dev/examples/number.clj
+++ b/dev/examples/number.clj
@@ -1,7 +1,6 @@
 ^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.number
-  #:nextjournal.clerk
-  {:toc true}
+  {:nextjournal.clerk/toc true}
   (:require [emmy.clerk :as ec]
             [emmy.mafs :as mafs]
             [nextjournal.clerk :as clerk]))

--- a/dev/examples/operator.clj
+++ b/dev/examples/operator.clj
@@ -1,6 +1,5 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
-(ns examples.operator)
+^{:nextjournal.clerk/visibility {:code :hide}}
+(ns examples.operator
+  {:nextjournal.clerk/toc true})
 
 ;; ## Operators

--- a/dev/examples/polynomial.clj
+++ b/dev/examples/polynomial.clj
@@ -1,7 +1,6 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
-(ns examples.polynomial)
+^{:nextjournal.clerk/visibility {:code :hide}}
+(ns examples.polynomial
+  {:nextjournal.clerk/toc true})
 
 ;; ## Polynomial
 ;;

--- a/dev/examples/power_series.clj
+++ b/dev/examples/power_series.clj
@@ -1,6 +1,5 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
-(ns examples.power-series)
+^{:nextjournal.clerk/visibility {:code :hide}}
+(ns examples.power-series
+  {:nextjournal.clerk/toc true})
 
 ;; ## Power Series

--- a/dev/examples/quaternion.clj
+++ b/dev/examples/quaternion.clj
@@ -1,6 +1,5 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
-(ns examples.quaternion)
+^{:nextjournal.clerk/visibility {:code :hide}}
+(ns examples.quaternion
+  {:nextjournal.clerk/toc true})
 
 ;; ## Quaternion

--- a/dev/examples/rational_function.clj
+++ b/dev/examples/rational_function.clj
@@ -1,7 +1,6 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
-(ns examples.rational-function)
+^{:nextjournal.clerk/visibility {:code :hide}}
+(ns examples.rational-function
+  {:nextjournal.clerk/toc true})
 
 ;; ## Rational Function
 

--- a/dev/examples/simulation/cylinder_flow.cljc
+++ b/dev/examples/simulation/cylinder_flow.cljc
@@ -1,7 +1,6 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.simulation.cylinder-flow
+  {:nextjournal.clerk/toc true}
   (:require
    [nextjournal.clerk #?(:clj :as :cljs :as-alias) clerk]
    [mentat.clerk-utils.show :refer [show-cljs]]

--- a/dev/examples/simulation/double_ellipsoid.clj
+++ b/dev/examples/simulation/double_ellipsoid.clj
@@ -1,5 +1,6 @@
 ^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.simulation.double-ellipsoid
+  {:nextjournal.clerk/toc true}
   (:refer-clojure
    :exclude [+ - * / = zero? compare
              numerator denominator ref partial])

--- a/dev/examples/simulation/ellipsoid.clj
+++ b/dev/examples/simulation/ellipsoid.clj
@@ -1,10 +1,11 @@
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.simulation.ellipsoid
+  {:nextjournal.clerk/toc true}
   (:refer-clojure
    :exclude [+ - * / = zero? compare
              numerator denominator ref partial])
   (:require [emmy.env :as e :refer :all]
             [emmy.expression.compile :as xc]
-
             [examples.expression :as d]
             [mathbox.core :as-alias mathbox]
             [mathbox.primitives :as-alias mb]

--- a/dev/examples/simulation/lorenz.cljc
+++ b/dev/examples/simulation/lorenz.cljc
@@ -1,7 +1,6 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.simulation.lorenz
+  {:nextjournal.clerk/toc true}
   (:require
    [nextjournal.clerk #?(:clj :as :cljs :as-alias) clerk]
    [mentat.clerk-utils.show :refer [show-cljs]]

--- a/dev/examples/simulation/oscillator.clj
+++ b/dev/examples/simulation/oscillator.clj
@@ -1,5 +1,6 @@
 ^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.simulation.oscillator
+  {:nextjournal.clerk/toc true}
   (:refer-clojure
    :exclude [+ - * / = zero? compare
              numerator denominator ref partial])

--- a/dev/examples/simulation/phase_portrait.cljc
+++ b/dev/examples/simulation/phase_portrait.cljc
@@ -74,7 +74,7 @@
       :start true
       :end true}]
     [mb/Format
-     {:expr demo.mathbox/format-number
+     {:expr emmy.mathbox.plot/format-number
       :font ["Helvetica"]}]
     [mb/Label
      {:color 0xffffff
@@ -95,7 +95,7 @@
       :end true
       :zero false}]
     [mb/Format
-     {:expr demo.mathbox/format-number
+     {:expr emmy.mathbox.plot/format-number
       :font ["Helvetica"]}]
     [mb/Label
      {:color 0xffffff
@@ -183,7 +183,7 @@
     [mathbox.primitives/Format
      {:expr
       (fn [x]
-        (str (demo.mathbox/format-number
+        (str (emmy.mathbox.plot/format-number
               (/ x Math/PI)) "π"))
       :font ["Helvetica"]}]
     [mathbox.primitives/Label
@@ -204,7 +204,7 @@
       :end true
       :zero false}]
     [mathbox.primitives/Format
-     {:expr demo.mathbox/format-number
+     {:expr emmy.mathbox.plot/format-number
       :font ["Helvetica"]}]
     [mathbox.primitives/Label
      {:color 0xffffff

--- a/dev/examples/simulation/phase_portrait.cljc
+++ b/dev/examples/simulation/phase_portrait.cljc
@@ -1,7 +1,6 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.simulation.phase-portrait
+  {:nextjournal.clerk/toc true}
   (:require [emmy.env :as e]
             #?(:clj [emmy.expression.compile :as xc])
             [nextjournal.clerk #?(:clj :as :cljs :as-alias) clerk]
@@ -74,7 +73,7 @@
       :start true
       :end true}]
     [mb/Format
-     {:expr emmy.mathbox.plot/format-number
+     {:expr emmy.viewer.plot/format-number
       :font ["Helvetica"]}]
     [mb/Label
      {:color 0xffffff
@@ -95,7 +94,7 @@
       :end true
       :zero false}]
     [mb/Format
-     {:expr emmy.mathbox.plot/format-number
+     {:expr emmy.viewer.plot/format-number
       :font ["Helvetica"]}]
     [mb/Label
      {:color 0xffffff
@@ -183,7 +182,7 @@
     [mathbox.primitives/Format
      {:expr
       (fn [x]
-        (str (emmy.mathbox.plot/format-number
+        (str (emmy.viewer.plot/format-number
               (/ x Math/PI)) "π"))
       :font ["Helvetica"]}]
     [mathbox.primitives/Label
@@ -204,7 +203,7 @@
       :end true
       :zero false}]
     [mathbox.primitives/Format
-     {:expr emmy.mathbox.plot/format-number
+     {:expr emmy.viewer.plot/format-number
       :font ["Helvetica"]}]
     [mathbox.primitives/Label
      {:color 0xffffff

--- a/dev/examples/simulation/quartic_well.cljc
+++ b/dev/examples/simulation/quartic_well.cljc
@@ -1,7 +1,6 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.simulation.quartic-well
+  {:nextjournal.clerk/toc true}
   (:require [emmy.env :as e]
             #?(:clj [emmy.expression.compile :as xc])
             [nextjournal.clerk #?(:clj :as :cljs :as-alias) clerk]
@@ -72,7 +71,7 @@
       :start true
       :end true}]
     [mb/Format
-     {:expr emmy.mathbox.plot/format-number
+     {:expr emmy.viewer.plot/format-number
       :font ["Helvetica"]}]
     [mb/Label
      {:color 0xffffff
@@ -93,7 +92,7 @@
       :end true
       :zero false}]
     [mb/Format
-     {:expr emmy.mathbox.plot/format-number
+     {:expr emmy.viewer.plot/format-number
       :font ["Helvetica"]}]
     [mb/Label
      {:color 0xffffff
@@ -172,7 +171,7 @@
       :start true
       :end true}]
     [mathbox.primitives/Format
-     {:expr emmy.mathbox.plot/format-number
+     {:expr emmy.viewer.plot/format-number
       :font ["Helvetica"]}]
     [mathbox.primitives/Label
      {:color 0xffffff
@@ -192,7 +191,7 @@
       :end true
       :zero false}]
     [mathbox.primitives/Format
-     {:expr emmy.mathbox.plot/format-number
+     {:expr emmy.viewer.plot/format-number
       :font ["Helvetica"]}]
     [mathbox.primitives/Label
      {:color 0xffffff

--- a/dev/examples/simulation/quartic_well.cljc
+++ b/dev/examples/simulation/quartic_well.cljc
@@ -72,7 +72,7 @@
       :start true
       :end true}]
     [mb/Format
-     {:expr demo.mathbox/format-number
+     {:expr emmy.mathbox.plot/format-number
       :font ["Helvetica"]}]
     [mb/Label
      {:color 0xffffff
@@ -93,7 +93,7 @@
       :end true
       :zero false}]
     [mb/Format
-     {:expr demo.mathbox/format-number
+     {:expr emmy.mathbox.plot/format-number
       :font ["Helvetica"]}]
     [mb/Label
      {:color 0xffffff
@@ -172,7 +172,7 @@
       :start true
       :end true}]
     [mathbox.primitives/Format
-     {:expr demo.mathbox/format-number
+     {:expr emmy.mathbox.plot/format-number
       :font ["Helvetica"]}]
     [mathbox.primitives/Label
      {:color 0xffffff
@@ -192,7 +192,7 @@
       :end true
       :zero false}]
     [mathbox.primitives/Format
-     {:expr demo.mathbox/format-number
+     {:expr emmy.mathbox.plot/format-number
       :font ["Helvetica"]}]
     [mathbox.primitives/Label
      {:color 0xffffff

--- a/dev/examples/simulation/toroid.clj
+++ b/dev/examples/simulation/toroid.clj
@@ -104,8 +104,7 @@
 ;; \phi)$-space.
 
 ^{::clerk/width :full}
-(ev/with-let [!params {:R 2 :r 0.5
-                       :theta_0 1 :alpha_0 0 :steps 1500}]
+(ev/with-let [!params {:R 2 :r 0.5 :theta_0 1 :alpha_0 0 :steps 1500}]
   (plot/scene
    (leva/controls
     {:atom !params

--- a/dev/examples/simulation/toroid.clj
+++ b/dev/examples/simulation/toroid.clj
@@ -1,4 +1,6 @@
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.simulation.toroid
+  {:nextjournal.clerk/toc true}
   (:refer-clojure
    :exclude [+ - * / = zero? compare
              numerator denominator ref partial
@@ -16,11 +18,11 @@
 
 ;; ## Geodesics of the Torus
 ;;
-;; Investigate the many interesting geodesics on the torus. This is
-;; similar to the [[examples.simulation.ellipsoid]] investigation, but
-;; here we will set gravity to zero and give our particle an initial
-;; velocity tangent to the toroidal surface and see where it will
-;; travel under the surface's intrinsic notion of free-fall.
+;; Investigate the many interesting geodesics on the torus. This is similar to
+;; the [[examples.simulation.ellipsoid]] investigation, but here we will set
+;; gravity to zero and give our particle an initial velocity tangent to the
+;; toroidal surface and see where it will travel under the surface's intrinsic
+;; notion of free-fall.
 ;;
 ;; First, prepare the viewers so that all literals render with the multiviewer:
 
@@ -28,16 +30,15 @@
 (clerk/add-viewers! [ec/meta-viewer d/multiviewer])
 
 ;; There is such a thing as toroidal coordinates--see
-;; [Wikipedia](https://en.wikipedia.org/wiki/Toroidal_coordinates)--
-;; but for our purposes those coordinates are unintuitive, and more
-;; useful in a 3d setting than we will need here. For us, living on
-;; the surface of the torus, we will describe our position by two
-;; angles: $\phi$, the azimuth, or the angle we make around the z
-;; axis measured in the xy plane which contains the torus' central
-;; axis circle of radios $R$, and $\theta$, the angle we make obout
-;; the central axis of the torus, where zero starts at the outer
-;; equator and $\pi$ represents the inner equator. The radius of
-;; the interior is denoted by $r$. Now...
+;; [Wikipedia](https://en.wikipedia.org/wiki/Toroidal_coordinates)-- but for our
+;; purposes those coordinates are unintuitive, and more useful in a 3d setting
+;; than we will need here. For us, living on the surface of the torus, we will
+;; describe our position by two angles: $\phi$, the azimuth, or the angle we
+;; make around the z axis measured in the xy plane which contains the torus'
+;; central axis circle of radios $R$, and $\theta$, the angle we make obout the
+;; central axis of the torus, where zero starts at the outer equator and $\pi$
+;; represents the inner equator. The radius of the interior is denoted by $r$.
+;; Now...
 
 (defn toroidal->rect [R r]
   (fn [[theta phi]]
@@ -51,10 +52,10 @@
   (comp (toroidal->rect R r)
         coordinate))
 
-;; Next, the Lagrangian. T, the kinetic energy, is just $mv^2/2$.
-;; For this demonstration, we aren't interested in dynamics, so
-;; we'll set $m$ to $1$ and forget about it for the rest of the
-;; page. Without gravity, there's no potential energy, so $V\equiv 0$.
+;; Next, the Lagrangian. T, the kinetic energy, is just $mv^2/2$. For this
+;; demonstration, we aren't interested in dynamics, so we'll set $m$ to $1$ and
+;; forget about it for the rest of the page. Without gravity, there's no
+;; potential energy, so $V\equiv 0$.
 
 (defn T-free-particle
   [[_ _ v]]
@@ -82,8 +83,8 @@
                 (up 'thetadot 'phidot))]
   ((L-toroidal 'R 'r) local))
 
-;; I was frankly expecting a little more trigonometry in there.
-;; Maybe I did something wrong. In any case, let's proceed.
+;; I was frankly expecting a little more trigonometry in there. Maybe I did
+;; something wrong. In any case, let's proceed.
 ;;
 ;; Lagrange equations of motion for the torus:
 
@@ -97,13 +98,14 @@
 ;; Ooof. Be careful what you ask for. Time to draw a picture.
 ;;
 ;; To influence the trajectory, you can choose the initial elevation on the
-;; upper half-torus by manipulating $\theta_0$. Imagine at that point there is
-;; a little unit circle allowing you to select the direction to proceed from
-;; there: this is $\alpha_0$, the direction of a unit vector in
-;; $(\theta, \phi)$-space.
+;; upper half-torus by manipulating $\theta_0$. Imagine at that point there is a
+;; little unit circle allowing you to select the direction to proceed from
+;; there: this is $\alpha_0$, the direction of a unit vector in $(\theta,
+;; \phi)$-space.
 
 ^{::clerk/width :full}
-(ev/with-let [!params {:R 2 :r 0.5 :theta_0 1 :alpha_0 0 :steps 1500}]
+(ev/with-let [!params {:R 2 :r 0.5
+                       :theta_0 1 :alpha_0 0 :steps 1500}]
   (plot/scene
    (leva/controls
     {:atom !params
@@ -111,8 +113,8 @@
      :schema
      {:R       {:min 0.5 :max 2 :step 0.01}
       :r       {:min 0.5 :max 2 :step 0.01}
-      :theta_0 {:min 0 :max Math/PI :step 0.02}
-      :alpha_0 {:min 0 :max Math/PI :step 0.02}
+      :theta_0 {:label (->infix 'theta_0) :min 0 :max Math/PI :step 0.02}
+      :alpha_0 {:label (->infix 'alpha_0) :min 0 :max Math/PI :step 0.02}
       :steps   {:min 500 :max 9000 :step 50}}})
 
    (ph/ode-curve

--- a/dev/examples/stern_brocot.clj
+++ b/dev/examples/stern_brocot.clj
@@ -1,7 +1,6 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.stern-brocot
+  {:nextjournal.clerk/toc true}
   (:refer-clojure
    :exclude
    [+ - * / = zero? compare numerator

--- a/dev/examples/structure.clj
+++ b/dev/examples/structure.clj
@@ -1,6 +1,5 @@
-^#:nextjournal.clerk
-{:toc true
- :visibility :hide-ns}
-(ns examples.structure)
+^{:nextjournal.clerk/visibility {:code :hide}}
+(ns examples.structure
+  {:nextjournal.clerk/toc true})
 
 ;; ## Structure

--- a/dev/examples/symbolic/einstein.clj
+++ b/dev/examples/symbolic/einstein.clj
@@ -1,4 +1,6 @@
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.symbolic.einstein
+  {:nextjournal.clerk/toc true}
   (:refer-clojure
    :exclude [+ - * / = zero? compare
              numerator denominator ref partial])

--- a/dev/examples/vega/pendulum.clj
+++ b/dev/examples/vega/pendulum.clj
@@ -7,7 +7,9 @@
 ;; the [Emmy](https://github.com/emmy/emmy) Clojure library and
 ;; the Clerk rendering environment.
 
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns examples.vega.pendulum
+  {:nextjournal.clerk/toc true}
   (:refer-clojure
    :exclude [+ - * / partial ref zero? numerator denominator compare = run!
              abs infinite?])

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -25,10 +25,10 @@
   {:index index
    :browse? true
    :watch-paths ["src" "dev"]
-   :custom-js ec/custom-js
+   ;; :custom-js ec/custom-js
 
    ;; Enable this and disable `:custom-js` to build new custom components.
-   ;; :cljs-namespaces '[emmy-viewers.sci-extensions]
+   :cljs-namespaces '[emmy-viewers.sci-extensions]
    })
 
 (def static-defaults

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,12 +1,9 @@
-(ns user
-  (:require [mentat.clerk-utils.build :as b]))
+(ns user)
 
 (try (requiring-resolve 'cljs.analyzer.api/ns-resolve) (catch Exception _ nil))
 (require '[emmy.env])
 (require '[emmy.expression.render :as xr])
 (require '[emmy.clerk :as ec])
-
-(ec/install-css!)
 
 (alter-var-root
  #'xr/*TeX-vertical-down-tuples*
@@ -25,9 +22,7 @@
   {:index index
    :browse? true
    :watch-paths ["src" "dev"]
-   ;; :custom-js ec/custom-js
-
-   ;; Enable this and disable `:custom-js` to build new custom components.
+   ;; Enable this when working on new components.
    :cljs-namespaces '[emmy-viewers.sci-extensions]
    })
 
@@ -41,11 +36,11 @@
 (defn serve!
   ([] (serve! {}))
   ([opts]
-   (b/serve!
+   (ec/serve!
     (merge defaults opts))))
 
-(def halt! b/halt!)
+(def halt! ec/halt!)
 
 (defn build! [opts]
-  (b/build!
+  (ec/build!
    (merge static-defaults opts)))

--- a/src/demo/mathbox.cljs
+++ b/src/demo/mathbox.cljs
@@ -12,23 +12,6 @@
             [reagent.core :as r])
   (:import [goog Timer]))
 
-(defn format-number [x]
-  (-> (.toFixed x 2)
-      (.replace #"\.0+$" "")))
-
-;; ## Components
-
-(defn Function1 [{:keys [samples f] :or {samples 256}}]
-  (let [f' (xc/sci-eval f)]
-    [:<>
-     [mb/Interval
-      {:width samples
-       :channels 2
-       :expr (fn [emit x _ time]
-               (emit x (f' x time)))}]
-     [mb/Line {:color 0x3090ff :width 4}]
-     [mb/Point {:color 0x3090ff :size 8}]]))
-
 ;; ## Simulation
 
 (defn Lagrangian-updater

--- a/src/emmy/clerk.clj
+++ b/src/emmy/clerk.clj
@@ -145,12 +145,15 @@
 
 (defn install!
   "Calling this function at the top of a Clerk notebook installs all appropriate
-  default viewers for Emmy.
+  default viewers for Emmy, along with any `viewers` supplied to [[install!]].
 
   [[install!]] is required for any Mafs, MathBox etc code to render correctly."
   [& viewers]
-  (clerk/add-viewers!
-   (into [meta-viewer literal-viewer] viewers)))
+  (let [high-priority [meta-viewer]
+        low-priority  [literal-viewer]]
+    (clerk/add-viewers!
+     (into high-priority
+           (concat viewers low-priority)))))
 
 ;; ### Project Configuration
 
@@ -244,7 +247,6 @@
          (b/build! (merge opts))
          (finally
            (apply css/set-css! existing)))))
-
 
 ;; ## State Utilities
 

--- a/src/emmy/clerk.clj
+++ b/src/emmy/clerk.clj
@@ -10,6 +10,7 @@
             [emmy.expression :as x]
             [emmy.viewer :as ev]
             [emmy.viewer.css :as vc]
+            [mentat.clerk-utils.build :as b]
             [mentat.clerk-utils.css :as css]
             [nextjournal.clerk :as clerk]))
 
@@ -166,6 +167,84 @@
   ([] (install-css! plugins))
   ([packages]
    (apply css/set-css! (mapcat vc/css-map packages))))
+
+(defn serve!
+  "Version of [[nextjournal.clerk/serve!]] that swaps out the default JS bundle
+  for a custom Emmy-Viewers bundle and installs all custom CSS for
+  emmy-viewers plugins.
+
+  In addition to all options supported by Clerk's `serve!`, [[serve!]] supports
+  the following options:
+
+  - `:cljs-namespaces`: a sequence of CLJS namespaces to compile and make
+    available to Clerk. If provided, [[serve!]] will compile a custom CLJS bundle
+    and configure Clerk to use this bundle instead of the Emmy-Viewers bundle.
+
+  - `:custom-js`: custom JS bundle to use instead of Emmy's JS.
+
+  - `:shadow-options`: these options are forwarded
+    to [[mentat.clerk-utils.build.shadow/watch!]]. See that function's docs for
+    more detail.
+
+    This bundle is served from a running shadow-cljs server and recompiled when
+    any dependency or namespace changes. Defaults to `nil`.
+
+  The only other difference is that if `(:browse? opts)` is `true`, [[serve!]]
+  calls [[nextjournal.clerk/show!]] automatically on `(:index opts)` if
+  provided.
+
+  All remaining `opts` are forwarded to [[nextjournal.clerk/serve!]]."
+  ([] (serve! {}))
+  ([opts]
+   (let [opts (cond-> opts
+                (or (:cljs-namespaces opts)
+                    (:custom-js opts))
+                (assoc :custom-js custom-js))]
+     (install-css!)
+     (b/serve! opts))))
+
+(defn halt!
+  "Version of [[nextjournal.clerk/halt!]] that additionally kills any shadow-cljs
+  processes, if they are running, and resets all custom CSS entries."
+  []
+  (css/reset-css!)
+  b/halt!)
+
+(defn build!
+  "Version of [[nextjournal.clerk/build!]] that swaps out the default JS bundle
+  for a custom Emmy-Viewers bundle and makes sure that all custom CSS for
+  emmy-viewers plugins is available during the build.
+
+  In addition to all options supported by Clerk's `build!`, [[build!]] supports
+  the following options:
+
+  - `:cljs-namespaces`: a sequence of CLJS namespaces to compile and make
+    available to Clerk. If provided, [[build!]] will compile a custom CLJS bundle
+    and configure Clerk to use this bundle instead of its default. Defaults to
+    `nil`.
+
+  - `:custom-js`: custom JS bundle to use instead of Emmy's built-in JS.
+
+  - `:cname`: string denoting the custom hostname from which the site will be
+    served. If provided, [[build!]] will create a `CNAME` file containing the
+    value in `(:out-path opts)`. Defaults to `nil`.
+
+  The only other difference is that [[build!]] populates `:git/sha` if it hasn't
+  been provided.
+
+  All remaining `opts` are forwarded to [[nextjournal.clerk/build!]]"
+  [opts]
+  (let [existing @css/custom-css
+        opts     (cond-> opts
+                   (or (:cljs-namespaces opts)
+                       (:custom-js opts))
+                   (assoc :custom-js custom-js))]
+
+    (try (install-css!)
+         (b/build! (merge opts))
+         (finally
+           (apply css/set-css! existing)))))
+
 
 ;; ## State Utilities
 

--- a/src/emmy/clerk.clj
+++ b/src/emmy/clerk.clj
@@ -147,9 +147,9 @@
   default viewers for Emmy.
 
   [[install!]] is required for any Mafs, MathBox etc code to render correctly."
-  []
+  [& viewers]
   (clerk/add-viewers!
-   [meta-viewer literal-viewer]))
+   (into [meta-viewer literal-viewer] viewers)))
 
 ;; ### Project Configuration
 

--- a/src/emmy/mathbox/compile.clj
+++ b/src/emmy/mathbox/compile.clj
@@ -4,15 +4,6 @@
             [emmy.viewer :as v]
             [emmy.viewer.compile :as vc]))
 
-(defn vectorize [f]
-  (if (v/param-f? f)
-    (update f :f
-            (fn [f]
-              (fn [& params]
-                (let [inner (apply f params)]
-                  (fn [[x]] (inner x))))))
-    (fn [[t]] (f t))))
-
 (defn frame
   "Given a map with entries:
 

--- a/src/emmy/mathbox/compile.clj
+++ b/src/emmy/mathbox/compile.clj
@@ -4,6 +4,15 @@
             [emmy.viewer :as v]
             [emmy.viewer.compile :as vc]))
 
+(defn vectorize [f]
+  (if (v/param-f? f)
+    (update f :f
+            (fn [f]
+              (fn [& params]
+                (let [inner (apply f params)]
+                  (fn [[x]] (inner x))))))
+    (fn [[t]] (f t))))
+
 (defn frame
   "Given a map with entries:
 

--- a/src/emmy/mathbox/physics.clj
+++ b/src/emmy/mathbox/physics.clj
@@ -1,0 +1,92 @@
+(ns emmy.mathbox.physics
+  "Server-side rendering functions for the components declared in the
+  [`emmy.mathbox.physics`](https://cljdoc.org/d/org.mentat/emmy-viewers/CURRENT/api/emmy.mathbox.physics)
+  namespace."
+  (:refer-clojure :exclude [vector])
+  (:require [emmy.expression.compile :as xc]
+            [emmy.mathbox.plot :as plot]
+            [emmy.viewer :as ev]
+            [emmy.viewer.compile :as vc]))
+
+(defn ^:no-doc ode-compile [opts k initial-state]
+  (let [v (get opts k)]
+    (if-not (vc/compile? v)
+      [[] opts]
+      (let [[v initial-state] (if (vector? initial-state)
+                                [v initial-state]
+                                [(vc/vectorize v) [initial-state]])
+            params?            (ev/param-f? v)
+            [f' params] (if params?
+                          [(:f v) (:params v)]
+                          [v false])
+            sym          (gensym)
+            simplify?    (:simplify? opts true)
+            [body new-f] [(xc/compile-state-fn
+                           f' params initial-state
+                           {:mode :js
+                            :generic-params? params?
+                            :simplify? simplify?
+                            :calling-convention :primitive})
+                          (if params?
+                            `(let [psym# (apply ~'array (map @~(:atom v) ~params))]
+                               (fn [in# out#]
+                                 (~sym in# out# psym#)))
+                            `(fn [in# out#]
+                               (~sym in# out# nil)))]]
+        [[sym (list* 'js/Function. body)]
+         (assoc opts k new-f)]))))
+
+(defn ode-curve
+  "Returns a fragment that plots a curve by integrating a system of ordinary
+  differential equations represented by `f'` forward from the initial input
+  state `initial-state` for `steps` steps of `dt` each.
+
+  Required arguments:
+
+  - `:f'`: function of the form `(fn [[y0 y1 ...]] [<y0'> <y1'> ...])` that
+    returns a vector of the derivatives of each input variable.
+
+  - `:initial-state`: the initial input vector to `:f'`.
+
+  Optional arguments:
+
+  - `:state->xyz`: function of the form `(fn [[y0 y1 ...]] [<x> <y> <z>])`,
+    responsible for transforming each integrated state into a 3D point. Defaults
+    to `identity`.
+
+  - `:steps`: the number of `:dt`-spaced steps for the integrator to take.
+    Defaults to 1000.
+
+  - `:dt`: the distance of each evenly spaced step taken by the integrator.
+    Defaults to 3e-2.
+
+  - `:epsilon`: error tolerance passed along
+    to [odex-js](https://github.com/littleredcomputer/odex-js). Defaults to 1e-5.
+
+  - `:width`: width of the curve. Defaults to 4.
+
+  - `:start?` if `true`, renders an arrow at the start of the curve. Defaults to
+    `false`.
+
+  - `:end?` if `true`, renders an arrow at the end of the curve. Defaults to
+    `false`.
+
+  - `:arrow-size`: size of the arrows toggled by `:start?` and `:end?`. Defaults
+    to 6.
+
+  - `:opacity`: opacity of the curve. Defaults to 1.0.
+
+  - `:color`: color of the curve. This can be a `three.js` `Color` object or [any
+    valid input to its constructor](https://threejs.org/docs/#api/en/math/Color).
+
+  - `:z-order`: z-order of the curve.
+
+  - `:z-index`: zIndex of the curve. Defaults to 0.
+
+  - `:z-bias`: zBias of the curve. Defaults to 0."
+  [{:keys [initial-state] :as opts}]
+  (let [[f-bind opts] (ode-compile opts :f' initial-state)
+        [x-bind opts] (ode-compile opts :state->xyz initial-state)]
+    (-> (vc/wrap [f-bind x-bind]
+                 ['emmy.mathbox.physics/ODECurve opts])
+        (ev/fragment plot/scene))))

--- a/src/emmy/mathbox/physics.clj
+++ b/src/emmy/mathbox/physics.clj
@@ -8,7 +8,22 @@
             [emmy.viewer :as ev]
             [emmy.viewer.compile :as vc]))
 
-(defn ^:no-doc ode-compile [opts k initial-state]
+(defn ^:no-doc ode-compile
+  "For generating compile fragments for use with Odex, or other applications that
+  provide inputs and outputs for the user.
+
+  Takes
+
+  - an options map `opts`
+  - the `k` that maps to the function to compile; this function should take a
+    flattened array of the same dimension as `initial-state`.
+  - an `initial-state`
+
+  and returns a pair of
+
+  - a new binding pair
+  - the options map updated to reference the new compiled fn via symbol."
+  [opts k initial-state]
   (let [v (get opts k)]
     (if-not (vc/compile? v)
       [[] opts]

--- a/src/emmy/mathbox/physics.cljs
+++ b/src/emmy/mathbox/physics.cljs
@@ -1,4 +1,5 @@
 (ns emmy.mathbox.physics
+  "ODE and physics-aware plotting functions using `MathBox`."
   (:require [emmy.viewer.physics :as ph]
             [mathbox.primitives :as mb]))
 

--- a/src/emmy/mathbox/physics.cljs
+++ b/src/emmy/mathbox/physics.cljs
@@ -12,7 +12,12 @@
     (fn [{:keys [f' y0 state->xyz steps dt epsilon]
          :or {steps 1000
               dt 3e-2
-              epsilon 1e-5}}]
+              epsilon 1e-5
+              state->xyz
+              (fn [in out]
+                (aset out 0 (aget in 0))
+                (aset out 1 (aget in 1))
+                (aset out 2 (aget in 2)))}}]
       [:<>
        [mb/Array
         {:channels 3

--- a/src/emmy/mathbox/physics.cljs
+++ b/src/emmy/mathbox/physics.cljs
@@ -1,0 +1,268 @@
+(ns emmy.mathbox.physics
+  (:require [emmy.viewer.physics :as ph]
+            [leva.core]
+            [mathbox.core]
+            [mathbox.primitives :as mb]
+            [nextjournal.clerk.render]
+            [reagent.core :as r]))
+
+(defn CurveSource
+  [{:keys [f' initial-state-fn params state->xyz steps dt]
+    :or {steps 1000 dt 3e-2}}]
+  [mb/Array
+   {:channels 3
+    :data
+    (let [y0  (initial-state-fn)
+          s   (ph/make-solver f' y0 {:parameters params :epsilon 1e-5})
+          ps  (.-state params)
+          xyz (double-array 3)
+          pts (atom [])]
+      (.solve s 0 (clj->js y0)
+              (* steps dt)
+              (.grid s dt
+                     (fn [_ ys]
+                       (state->xyz ys xyz ps)
+                       (swap! pts conj #js [(aget xyz 0)
+                                            (aget xyz 2)
+                                            (aget xyz 1)]))))
+      @pts)}])
+
+(defn Curve
+  "Component that takes a simulator and builds an array of points connected
+   into a curve."
+  [opts]
+  [:<>
+   [CurveSource opts]
+   [mb/Line
+    {:color 0xff3090
+     :size 8
+     :points "<"
+     :end true}]])
+
+(defn Tail [{:keys [length] :as opts}]
+  [:<>
+   [mb/Spread {:height [0 0 -0.02] :alignHeight -1}]
+   ;; This is the color channel, and fades out the tail as you go.
+   [mb/Array
+    {:width length
+     :channels 4
+     :expr (fn [emit i]
+             (emit 1 1 1 (- 1 (/ i 16))))}]
+   [mb/Transpose {:order "zxy"}]
+   [mb/Point
+    (-> (dissoc opts :length)
+        (assoc :points "<<<"
+               :colors "<"))]])
+
+(defn Comet
+  "Path is a function of i, t
+  dimensions is how many you want to emit
+  history is tail length,
+  rest of options go to the final point
+
+  Note that i think we have to emit with xzy?? weird..."
+  [{:keys [dimensions path length items]
+    :or {items 1}
+    :as opts}]
+  [:<>
+   [mb/Array
+    {:history length
+     :items items
+     :channels dimensions
+     :expr path}]
+   [Tail (dissoc opts :dimensions :path :items)]])
+
+(defn Mass
+  "TODO if I make a 2-level component to compile the function then what the heck
+  do I do if it changes? Do I not worry about that?
+
+  TODO I made it here so it's already compiled... does that make sense??"
+  [{state->xyz :state->xyz
+    !state     :atom
+    params     :params}]
+  [Comet
+   {:dimensions 3
+    :length 16
+    :color 0x3090ff
+    :size 10
+    :opacity 0.99
+    :path
+    (let [out #js [0 0 0]]
+      (fn [emit _ _]
+        (state->xyz (.-state !state) out params)
+        (emit (aget out 0)
+              (aget out 2)
+              (aget out 1))))}])
+
+(def ^:private two-pi (* 2 Math/PI))
+
+;; TODO make this generic?
+(defn Ellipse [{:keys [a b c]}]
+  [:<>
+   [mb/Area
+    {:width 64
+     :height 64
+     :rangeX [0 two-pi]
+     :rangeY [0 two-pi]
+     :axes [1 3]
+     :live false
+     :expr (fn [emit theta phi _i _j _time]
+             (let [sin-theta (Math/sin theta)
+                   cos-theta (Math/cos theta)]
+               ;; xzy
+               (emit
+                (* a sin-theta (Math/cos phi))
+                (* c cos-theta)
+                (* b sin-theta (Math/sin phi)))))
+     :items 1
+     :channels 3}]
+   [mb/Surface
+    {:shaded true
+     :opacity 0.2
+     :lineX true
+     :lineY true
+     :points "<"
+     :color 0xffffff
+     :width 1}]])
+
+(defn Torus [render-fn !params]
+  [:<>
+   [mb/Area
+    {:width 64
+     :height 64
+     :rangeX [0 two-pi]
+     :rangeY [0 two-pi]
+     :axes [1 3]
+     :live false
+     :expr (let [in  #js [0 0 0 0 0]
+                 out #js [0 0 0]
+                 p   @!params]
+             (fn [emit theta phi _i _j _time]
+               (aset in 1 theta)
+               (aset in 2 phi)
+               (render-fn in out p)
+               (emit (aget out 0)
+                     (aget out 2)
+                     (aget out 1))))
+     :items 1
+     :channels 3}]
+   [mb/Surface
+    {:shaded true
+     :opacity 0.5
+     :lineX true
+     :lineY true
+     :points "<"
+     :color 0xffffff
+     :width 1}]])
+
+;; ## Toroid Viewer
+
+(defn ToroidViewer
+  [{params     :params
+    keys       :keys
+    schema     :schema
+    state->xyz :state->xyz
+    :as opts}]
+  (reagent.core/with-let
+    [render-fn (apply js/Function state->xyz)
+     !params   (reagent.core/atom params)
+     ;; I had to move this here because reagent.core/reaction wasn't available
+     ;; in the SCI environment you have when writing viewers...
+     !arr      (reagent.core/reaction
+                (apply
+                 array
+                 (map @!params keys)))]
+    [:<>
+     [nextjournal.clerk.render/inspect @!arr]
+     [leva.core/Controls
+      {:atom !params
+       :schema schema}]
+     [mathbox.core/MathBox
+      {:container  {:style {:height "400px" :width "100%"}}
+       :threestrap {:plugins ["core" "controls" "cursor" "stats"]}
+       :renderer   {:background-color 0xffffff}}
+      [mb/Cartesian (:cartesian opts)
+       [mb/Axis {:axis 1 :width 3}]
+       [mb/Axis {:axis 2 :width 3}]
+       [mb/Axis {:axis 3 :width 3}]
+       [Curve
+        {:state-derivative (apply js/Function (:L opts))
+         :state->xyz render-fn
+         :initial-state-fn
+         (fn []
+           (let [st      (.-state !params)
+                 alpha_0 (:alpha_0 st)]
+             ;; alpha_0 is the direction of the initial velocity
+             ;; in (theta, phi)-space. Since we're not doing dynamics,
+             ;; the speed doesn't matter, just the direction, so we do
+             ;; it as a unit vector.
+             [0
+              (:theta_0 st)
+              0
+              (Math/cos alpha_0) (Math/sin alpha_0)]))
+         :steps 1500
+         :params !arr}]
+       [Torus render-fn !arr]]]]))
+
+(defn ToroidPoint
+  [{state      :initial-state
+    params     :params
+    keys       :keys
+    schema     :schema
+    state->xyz :state->xyz
+    :as opts}]
+  (reagent.core/with-let
+    [render-fn (apply js/Function state->xyz)
+     !state    (reagent.core/atom {:time 0 :state state})
+     !params   (reagent.core/atom params)
+     ;; I had to move this here because reagent.core/reaction wasn't available
+     ;; in the SCI environment you have when writing viewers...
+     !arr      (reagent.core/reaction
+                (apply
+                 array
+                 (map @!params keys)))]
+    [:<>
+     [nextjournal.clerk.render/inspect @!arr]
+     [nextjournal.clerk.render/inspect @!state]
+     [leva.core/Controls
+      {:atom !params
+       :schema schema}]
+     [ph/Evolve
+      {:L      (:L opts)
+       :params !arr
+       :atom   !state}]
+     [mathbox.core/MathBox
+      {:container  {:style {:height "400px" :width "100%"}}
+       :threestrap {:plugins ["core" "controls" "cursor" "stats"]}
+       :renderer   {:background-color 0xffffff}}
+      [mb/Cartesian (:cartesian opts)
+       [mb/Axis {:axis 1 :width 3}]
+       [mb/Axis {:axis 2 :width 3}]
+       [mb/Axis {:axis 3 :width 3}]
+       [Curve
+        {:state-derivative (apply js/Function (:L opts))
+         :state->xyz render-fn
+         :initial-state-fn
+         (fn []
+           (let [s (:state (.-state !state))]
+             (if (array? s)
+               s
+               (clj->js (flatten s)))))
+         :steps 200
+         :params !arr}]
+       [Comet
+        {:dimensions 3
+         :length 20
+         :color 0xa0d0ff
+         :size 10
+         :opacity 0.99
+         :path
+         (let [out #js [0 0 0]]
+           (fn [emit _ _]
+             (render-fn (:state (.-state !state))
+                        out
+                        (.-state !arr))
+             (emit (aget out 0)
+                   (aget out 2)
+                   (aget out 1))))}]
+       [Torus render-fn !arr]]]]))

--- a/src/emmy/mathbox/physics.cljs
+++ b/src/emmy/mathbox/physics.cljs
@@ -3,41 +3,39 @@
             [leva.core]
             [mathbox.core]
             [mathbox.primitives :as mb]
-            [nextjournal.clerk.render]
-            [reagent.core :as r]))
-
-(defn CurveSource
-  [{:keys [f' initial-state-fn params state->xyz steps dt]
-    :or {steps 1000 dt 3e-2}}]
-  [mb/Array
-   {:channels 3
-    :data
-    (let [y0  (initial-state-fn)
-          s   (ph/make-solver f' y0 {:parameters params :epsilon 1e-5})
-          ps  (.-state params)
-          xyz (double-array 3)
-          pts (atom [])]
-      (.solve s 0 (clj->js y0)
-              (* steps dt)
-              (.grid s dt
-                     (fn [_ ys]
-                       (state->xyz ys xyz ps)
-                       (swap! pts conj #js [(aget xyz 0)
-                                            (aget xyz 2)
-                                            (aget xyz 1)]))))
-      @pts)}])
+            [nextjournal.clerk.render]))
 
 (defn Curve
-  "Component that takes a simulator and builds an array of points connected
-   into a curve."
-  [opts]
-  [:<>
-   [CurveSource opts]
-   [mb/Line
-    {:color 0xff3090
-     :size 8
-     :points "<"
-     :end true}]])
+  "TODO try to use point-integrator in the other namespace."
+  [_]
+  (let [xyz #js [0 0 0]]
+    (fn [{:keys [f' y0 state->xyz steps dt epsilon]
+         :or {steps 1000
+              dt 3e-2
+              epsilon 1e-5}}]
+      [:<>
+       [mb/Array
+        {:channels 3
+         :data
+         (let [s   (ph/make-solver f' (count y0) {:epsilon epsilon})
+               pts (js/Array. steps)
+               idx (volatile! -1)]
+           (.solve s 0 (clj->js y0)
+                   (* steps dt)
+                   (.grid s dt
+                          (fn [_ ys]
+                            (state->xyz ys xyz)
+                            (aset pts
+                                  (vswap! idx inc)
+                                  #js [(aget xyz 0)
+                                       (aget xyz 2)
+                                       (aget xyz 1)]))))
+           pts)}]
+       [mb/Line
+        {:color 0xff3090
+         :size 8
+         :points "<"
+         :end true}]])))
 
 (defn Tail [{:keys [length] :as opts}]
   [:<>
@@ -93,176 +91,3 @@
         (emit (aget out 0)
               (aget out 2)
               (aget out 1))))}])
-
-(def ^:private two-pi (* 2 Math/PI))
-
-;; TODO make this generic?
-(defn Ellipse [{:keys [a b c]}]
-  [:<>
-   [mb/Area
-    {:width 64
-     :height 64
-     :rangeX [0 two-pi]
-     :rangeY [0 two-pi]
-     :axes [1 3]
-     :live false
-     :expr (fn [emit theta phi _i _j _time]
-             (let [sin-theta (Math/sin theta)
-                   cos-theta (Math/cos theta)]
-               ;; xzy
-               (emit
-                (* a sin-theta (Math/cos phi))
-                (* c cos-theta)
-                (* b sin-theta (Math/sin phi)))))
-     :items 1
-     :channels 3}]
-   [mb/Surface
-    {:shaded true
-     :opacity 0.2
-     :lineX true
-     :lineY true
-     :points "<"
-     :color 0xffffff
-     :width 1}]])
-
-(defn Torus [render-fn !params]
-  [:<>
-   [mb/Area
-    {:width 64
-     :height 64
-     :rangeX [0 two-pi]
-     :rangeY [0 two-pi]
-     :axes [1 3]
-     :live false
-     :expr (let [in  #js [0 0 0 0 0]
-                 out #js [0 0 0]
-                 p   @!params]
-             (fn [emit theta phi _i _j _time]
-               (aset in 1 theta)
-               (aset in 2 phi)
-               (render-fn in out p)
-               (emit (aget out 0)
-                     (aget out 2)
-                     (aget out 1))))
-     :items 1
-     :channels 3}]
-   [mb/Surface
-    {:shaded true
-     :opacity 0.5
-     :lineX true
-     :lineY true
-     :points "<"
-     :color 0xffffff
-     :width 1}]])
-
-;; ## Toroid Viewer
-
-(defn ToroidViewer
-  [{params     :params
-    keys       :keys
-    schema     :schema
-    state->xyz :state->xyz
-    :as opts}]
-  (reagent.core/with-let
-    [render-fn (apply js/Function state->xyz)
-     !params   (reagent.core/atom params)
-     ;; I had to move this here because reagent.core/reaction wasn't available
-     ;; in the SCI environment you have when writing viewers...
-     !arr      (reagent.core/reaction
-                (apply
-                 array
-                 (map @!params keys)))]
-    [:<>
-     [nextjournal.clerk.render/inspect @!arr]
-     [leva.core/Controls
-      {:atom !params
-       :schema schema}]
-     [mathbox.core/MathBox
-      {:container  {:style {:height "400px" :width "100%"}}
-       :threestrap {:plugins ["core" "controls" "cursor" "stats"]}
-       :renderer   {:background-color 0xffffff}}
-      [mb/Cartesian (:cartesian opts)
-       [mb/Axis {:axis 1 :width 3}]
-       [mb/Axis {:axis 2 :width 3}]
-       [mb/Axis {:axis 3 :width 3}]
-       [Curve
-        {:state-derivative (apply js/Function (:L opts))
-         :state->xyz render-fn
-         :initial-state-fn
-         (fn []
-           (let [st      (.-state !params)
-                 alpha_0 (:alpha_0 st)]
-             ;; alpha_0 is the direction of the initial velocity
-             ;; in (theta, phi)-space. Since we're not doing dynamics,
-             ;; the speed doesn't matter, just the direction, so we do
-             ;; it as a unit vector.
-             [0
-              (:theta_0 st)
-              0
-              (Math/cos alpha_0) (Math/sin alpha_0)]))
-         :steps 1500
-         :params !arr}]
-       [Torus render-fn !arr]]]]))
-
-(defn ToroidPoint
-  [{state      :initial-state
-    params     :params
-    keys       :keys
-    schema     :schema
-    state->xyz :state->xyz
-    :as opts}]
-  (reagent.core/with-let
-    [render-fn (apply js/Function state->xyz)
-     !state    (reagent.core/atom {:time 0 :state state})
-     !params   (reagent.core/atom params)
-     ;; I had to move this here because reagent.core/reaction wasn't available
-     ;; in the SCI environment you have when writing viewers...
-     !arr      (reagent.core/reaction
-                (apply
-                 array
-                 (map @!params keys)))]
-    [:<>
-     [nextjournal.clerk.render/inspect @!arr]
-     [nextjournal.clerk.render/inspect @!state]
-     [leva.core/Controls
-      {:atom !params
-       :schema schema}]
-     [ph/Evolve
-      {:L      (:L opts)
-       :params !arr
-       :atom   !state}]
-     [mathbox.core/MathBox
-      {:container  {:style {:height "400px" :width "100%"}}
-       :threestrap {:plugins ["core" "controls" "cursor" "stats"]}
-       :renderer   {:background-color 0xffffff}}
-      [mb/Cartesian (:cartesian opts)
-       [mb/Axis {:axis 1 :width 3}]
-       [mb/Axis {:axis 2 :width 3}]
-       [mb/Axis {:axis 3 :width 3}]
-       [Curve
-        {:state-derivative (apply js/Function (:L opts))
-         :state->xyz render-fn
-         :initial-state-fn
-         (fn []
-           (let [s (:state (.-state !state))]
-             (if (array? s)
-               s
-               (clj->js (flatten s)))))
-         :steps 200
-         :params !arr}]
-       [Comet
-        {:dimensions 3
-         :length 20
-         :color 0xa0d0ff
-         :size 10
-         :opacity 0.99
-         :path
-         (let [out #js [0 0 0]]
-           (fn [emit _ _]
-             (render-fn (:state (.-state !state))
-                        out
-                        (.-state !arr))
-             (emit (aget out 0)
-                   (aget out 2)
-                   (aget out 1))))}]
-       [Torus render-fn !arr]]]]))

--- a/src/emmy/mathbox/plot.clj
+++ b/src/emmy/mathbox/plot.clj
@@ -301,15 +301,8 @@
   - `:z-index`: zIndex of the curve. Defaults to 0.
 
   - `:z-bias`: zBias of the curve. Defaults to 0."
-  [{:keys [f] :as opts}]
-  (let [opts (if (ev/param-f? f)
-               (update opts :f
-                       update :f
-                       (fn [f]
-                         (fn [& params]
-                           (let [inner (apply f params)]
-                             (fn [[x]] (inner x))))))
-               (assoc opts :f (fn [[t]] (f t))))
+  [opts]
+  (let [opts          (update opts :f c/vectorize)
         [f-bind opts] (mc/compile-3d opts :f 1)]
     (-> (c/wrap [f-bind] ['emmy.mathbox.plot/ParametricCurve opts])
         (ev/fragment scene))))

--- a/src/emmy/mathbox/plot.cljs
+++ b/src/emmy/mathbox/plot.cljs
@@ -425,7 +425,7 @@
         {:keys [camera range scale axes grids]
          :or {range  [[-5 5] [-5 5] [-5 5]]
               scale  [1 1 1]
-              camera [0.5 0.6 2]
+              camera [0.5 2 0.6]
               axes  [:x :y :z]
               grids [:xy]}} opts
         range [(range 0) (range 2) (range 1)]]

--- a/src/emmy/mathbox/plot.cljs
+++ b/src/emmy/mathbox/plot.cljs
@@ -430,8 +430,9 @@
               grids [:xy]}} opts
         range [(range 0) (range 2) (range 1)]]
     [mb/Cartesian
-     {:range range :scale scale}
-     [mb/Camera {:proxy true :position camera}]
+     {:range range :scale [(nth scale 0) (nth scale 2) (nth scale 1)]}
+     [mb/Camera
+      {:proxy true :position [(nth camera 0) (nth camera 2) (nth camera 1)]}]
      (into [:<>] children)
      [SceneAxes axes range]
      [SceneGrids grids]]))

--- a/src/emmy/viewer/compile.clj
+++ b/src/emmy/viewer/compile.clj
@@ -26,6 +26,15 @@
   (and (map? m)
        (not (v/param-f? m))))
 
+(defn vectorize [f]
+  (if (v/param-f? f)
+    (update f :f
+            (fn [f]
+              (fn [& params]
+                (let [inner (apply f params)]
+                  (fn [[x]] (inner x))))))
+    (fn [[t]] (f t))))
+
 ;; ## Compile Functions
 
 (defn param-1d

--- a/src/emmy/viewer/compile.clj
+++ b/src/emmy/viewer/compile.clj
@@ -26,7 +26,10 @@
   (and (map? m)
        (not (v/param-f? m))))
 
-(defn vectorize [f]
+(defn vectorize
+  "Given a function `f` (parametrized or not) of a single non-vector argument,
+  returns a similar version that takes `[x]` instead of `x`."
+  [f]
   (if (v/param-f? f)
     (update f :f
             (fn [f]

--- a/src/emmy/viewer/physics.cljs
+++ b/src/emmy/viewer/physics.cljs
@@ -1,20 +1,29 @@
 (ns emmy.viewer.physics
-  (:require [emmy.viewer.stopwatch :as sw]
-            ["odex" :as o]))
-
-
+  "ODE and physics-aware utilities for all Emmy-Viewers plugins."
+  (:require ["odex" :as o]))
 
 ;; ## Simulation
-;;
-;; Okay, so we have two ideas here.
 
 (def ^:private default-epsilon 1e-6)
 
-;; I am PRETTY sure that in all cases I can find a way to wire in the params
-;; without passing them here. TODO check the existing case and see what works.
-
 (defn make-solver
-  "TODO take more odex options."
+  "Given
+
+  - `f'`, a function of 2-arguments `state` and `output`, that populates
+    `output` with the derivatives for each entry in `state` when called
+
+  - `dimension`, the number of entries in `f'`'s `state` argument
+
+  and an options map with the following optional entries:
+
+  - `:epsilon`: - `:epsilon`: error tolerance passed along
+    to [odex-js](https://github.com/littleredcomputer/odex-js). Defaults to 1e-6.
+
+  - `:max-steps`: the maximum number of steps that the ODE solver will take
+    before erroring out. Defaults to 10000.
+
+  Returns an instance of
+  an [odex-js](https://github.com/littleredcomputer/odex-js) [Solver](https://github.com/littleredcomputer/odex-js/blob/master/src/odex.ts#L41)."
   [f' dimension {:keys [epsilon max-steps]}]
   (let [epsilon   (or epsilon default-epsilon)
         max-steps (or max-steps 10000)]
@@ -26,36 +35,31 @@
           :rawFunction true
           :maxSteps max-steps})))
 
-(defn ^:no-doc ->arr
-  "TODO should we use `ode/flatten-into-primitive-array`?"
-  [xs]
-  (double-array
-   (if (array? xs)
-     xs
-     (flatten xs))))
-
-(defn monotonic-integrator
-  "Takes
-
-  - `f'`
-  - an initial station
-  - optionally, `opts`...
-
-  Returns a function, monotonic in its single numeric argument, that represents
-  the integral of the function f' given the initial data $y_0 = f(x_0)$ and an
-  options dictionary (presently containing the tolerance for error $\\epsilon$,
-  but eventually also selecting from a menu of integration techniques)."
-  ([f' initial-state]
-   (monotonic-integrator f' initial-state {}))
-  ([f' initial-state opts]
-   (let [arr (->arr initial-state)]
-     (-> (make-solver f' (count arr) opts)
-         (.integrate 0 arr)))))
-
-;; TODO fix the case where we have issues at simSteps 5 on phase
-;; portrait.
 (defn point-integrator
-  "hardcoded at first for this use case."
+  "Given
+
+  - `f'`, a function of 2-arguments `state` and `output`, that populates
+    `output` with the derivatives for each entry in `state` when called
+
+  - `dimension`, the number of entries in `f'`'s `state` argument
+
+  and an options map with the following optional entries:
+
+  - `:epsilon`: - `:epsilon`: error tolerance passed along
+    to [odex-js](https://github.com/littleredcomputer/odex-js). Defaults to 1e-6.
+
+  - `:max-steps`: the maximum number of steps that the ODE solver will take
+    before erroring out. Defaults to 10000.
+
+  Returns a function of:
+
+  - `initial-state`
+  - `n-steps`, the number of steps to integrate
+  - `step-size`, the distance for each step
+  - `emit`, a callback called with a JS array representing the updated state for
+    each integration step of size `step-size`.
+
+  This function can be used multiple times."
   ([f' dimension]
    (point-integrator f' dimension {}))
   ([f' dimension opts]
@@ -65,23 +69,3 @@
                (.grid solver step-size
                       (fn [_ ys]
                         (emit ys))))))))
-
-;; ## Components
-
-(defn Evolve
-  "ODE State evolving component."
-  [{f'      :derivative
-    !state  :atom
-    !params :params}]
-  (let [init   (:state @!state)
-        opts   {:parameters !params}
-        update (monotonic-integrator f' init opts)]
-    (fn [_]
-      [sw/Stopwatch
-       {:onTick
-        (fn [t]
-          ;; TODO can we keep the output here mutable and provide an out to
-          ;; update?
-          (swap! !state assoc
-                 :time t
-                 :state (update t)))}])))

--- a/src/emmy/viewer/physics.cljs
+++ b/src/emmy/viewer/physics.cljs
@@ -1,0 +1,87 @@
+(ns emmy.viewer.physics
+  (:require [emmy.viewer.stopwatch :as sw]
+            ["odex" :as o]))
+
+
+
+;; ## Simulation
+;;
+;; Okay, so we have two ideas here.
+
+(def ^:private default-epsilon 1e-6)
+
+;; I am PRETTY sure that in all cases I can find a way to wire in the params
+;; without passing them here. TODO check the existing case and see what works.
+
+(defn make-solver
+  "TODO take more odex options."
+  [f' dimension {:keys [epsilon max-steps]}]
+  (let [epsilon   (or epsilon default-epsilon)
+        max-steps (or max-steps 10000)]
+    (o/Solver.
+     (fn [_ ys yps] (f' ys yps))
+     dimension
+     #js {:absoluteTolerance epsilon
+          :relativeTolerance epsilon
+          :rawFunction true
+          :maxSteps max-steps})))
+
+(defn ^:no-doc ->arr
+  "TODO should we use `ode/flatten-into-primitive-array`?"
+  [xs]
+  (double-array
+   (if (array? xs)
+     xs
+     (flatten xs))))
+
+(defn monotonic-integrator
+  "Takes
+
+  - `f'`
+  - an initial station
+  - optionally, `opts`...
+
+  Returns a function, monotonic in its single numeric argument, that represents
+  the integral of the function f' given the initial data $y_0 = f(x_0)$ and an
+  options dictionary (presently containing the tolerance for error $\\epsilon$,
+  but eventually also selecting from a menu of integration techniques)."
+  ([f' initial-state]
+   (monotonic-integrator f' initial-state {}))
+  ([f' initial-state opts]
+   (let [arr (->arr initial-state)]
+     (-> (make-solver f' (count arr) opts)
+         (.integrate 0 arr)))))
+
+;; TODO fix the case where we have issues at simSteps 5 on phase
+;; portrait.
+(defn point-integrator
+  "hardcoded at first for this use case."
+  ([f' dimension]
+   (point-integrator f' dimension {}))
+  ([f' dimension opts]
+   (let [solver (make-solver f' dimension opts)]
+     (fn [initial-state n-steps step-size emit]
+       (.solve solver 0 initial-state (* n-steps step-size)
+               (.grid solver step-size
+                      (fn [_ ys]
+                        (emit ys))))))))
+
+;; ## Components
+
+(defn Evolve
+  "ODE State evolving component."
+  [{f'      :derivative
+    !state  :atom
+    !params :params}]
+  (let [init   (:state @!state)
+        opts   {:parameters !params}
+        update (monotonic-integrator f' init opts)]
+    (fn [_]
+      [sw/Stopwatch
+       {:onTick
+        (fn [t]
+          ;; TODO can we keep the output here mutable and provide an out to
+          ;; update?
+          (swap! !state assoc
+                 :time t
+                 :state (update t)))}])))

--- a/src/emmy/viewer/sci.cljs
+++ b/src/emmy/viewer/sci.cljs
@@ -1,8 +1,10 @@
 (ns emmy.viewer.sci
   (:require [demo.mathbox]
             [demo.mathlive]
+            [emmy.mathbox.physics]
             [emmy.mathbox.plot]
             [emmy.viewer.plot]
+            [emmy.viewer.stopwatch]
             [leva.sci]
             [emmy.sci]
             [mafs.sci]
@@ -22,7 +24,9 @@
   (sci.ctx-store/swap-ctx!
    sci/merge-opts
    {:namespaces
-    {'demo.mathbox      (sci/copy-ns demo.mathbox (sci/create-ns 'demo.mathbox))
-     'demo.mathlive     (sci/copy-ns demo.mathlive (sci/create-ns 'demo.mathlive))
-     'emmy.mathbox.plot (sci/copy-ns emmy.mathbox.plot (sci/create-ns 'emmy.mathbox.plot))
-     'emmy.viewer.plot  (sci/copy-ns emmy.viewer.plot (sci/create-ns 'emmy.viewer.plot))}}))
+    {'demo.mathbox          (sci/copy-ns demo.mathbox (sci/create-ns 'demo.mathbox))
+     'demo.mathlive         (sci/copy-ns demo.mathlive (sci/create-ns 'demo.mathlive))
+     'emmy.mathbox.physics  (sci/copy-ns emmy.mathbox.physics (sci/create-ns 'emmy.mathbox.physics))
+     'emmy.mathbox.plot     (sci/copy-ns emmy.mathbox.plot (sci/create-ns 'emmy.mathbox.plot))
+     'emmy.viewer.plot      (sci/copy-ns emmy.viewer.plot (sci/create-ns 'emmy.viewer.plot))
+     'emmy.viewer.stopwatch (sci/copy-ns emmy.viewer.stopwatch (sci/create-ns 'emmy.viewer.stopwatch))}}))

--- a/src/emmy/viewer/sci.cljs
+++ b/src/emmy/viewer/sci.cljs
@@ -3,6 +3,7 @@
             [demo.mathlive]
             [emmy.mathbox.physics]
             [emmy.mathbox.plot]
+            [emmy.viewer.physics]
             [emmy.viewer.plot]
             [emmy.viewer.stopwatch]
             [leva.sci]
@@ -28,5 +29,6 @@
      'demo.mathlive         (sci/copy-ns demo.mathlive (sci/create-ns 'demo.mathlive))
      'emmy.mathbox.physics  (sci/copy-ns emmy.mathbox.physics (sci/create-ns 'emmy.mathbox.physics))
      'emmy.mathbox.plot     (sci/copy-ns emmy.mathbox.plot (sci/create-ns 'emmy.mathbox.plot))
+     'emmy.viewer.physics   (sci/copy-ns emmy.viewer.physics (sci/create-ns 'emmy.viewer.physics))
      'emmy.viewer.plot      (sci/copy-ns emmy.viewer.plot (sci/create-ns 'emmy.viewer.plot))
      'emmy.viewer.stopwatch (sci/copy-ns emmy.viewer.stopwatch (sci/create-ns 'emmy.viewer.stopwatch))}}))

--- a/src/emmy/viewer/stopwatch.clj
+++ b/src/emmy/viewer/stopwatch.clj
@@ -1,5 +1,5 @@
 (ns emmy.viewer.stopwatch
-  "Clock component!")
+  "Alpha component for running a stopwatch inside Reagent.")
 
 (defn stopwatch
   "Returns a reagent fragment that renders a Clock component into the scene."

--- a/src/emmy/viewer/stopwatch.clj
+++ b/src/emmy/viewer/stopwatch.clj
@@ -1,0 +1,7 @@
+(ns emmy.viewer.stopwatch
+  "Clock component!")
+
+(defn stopwatch
+  "Returns a reagent fragment that renders a Clock component into the scene."
+  [opts]
+  ['emmy.viewer.stopwatch/Stopwatch opts])

--- a/src/emmy/viewer/stopwatch.cljs
+++ b/src/emmy/viewer/stopwatch.cljs
@@ -1,5 +1,5 @@
 (ns emmy.viewer.stopwatch
-  "Timer component, useful for various animations.
+  "Stopwatch component, useful for various animations.
 
   NOTE that this is currently implemented with `goog.Timer`. For Portal
   compatibility, I'll back this out soon and rewrite the component using request

--- a/src/emmy/viewer/stopwatch.cljs
+++ b/src/emmy/viewer/stopwatch.cljs
@@ -1,0 +1,68 @@
+(ns emmy.viewer.stopwatch
+  "Timer component, useful for various animations.
+
+  NOTE that this is currently implemented with `goog.Timer`. For Portal
+  compatibility, I'll back this out soon and rewrite the component using request
+  AnimationFrame."
+  (:require [goog.events]
+            [goog.Timer :as timer]
+            ["react" :as react])
+  (:import [goog Timer]))
+
+;; TODO rewrite as useStopwatch for compatibility with Portal and friends:
+;; https://github.com/stevenpetryk/mafs/blob/main/src/animation/useStopwatch.ts
+
+(defn Stopwatch*
+  "Function component for a relative clock. `onTick` is called with a single arg
+  for seconds."
+  [{:keys [interval running? onTick]
+    :or   {running? true
+           interval 1}}]
+  ;; TODO move to outer??
+  (let [t   (Timer.)
+        now (goog/now)]
+    (react/useEffect
+     (fn mount []
+       (fn unmount []
+         (.dispose t)))
+     #js [])
+
+    (react/useEffect
+     (fn mount []
+       (if (.-enabled t)
+         (when-not running? (.stop t))
+         (when running? (.start t)))
+       js/undefined)
+     #js [running?])
+
+    (react/useEffect
+     (fn mount []
+       (when interval
+         (.setInterval t interval))
+       js/undefined)
+     #js [interval])
+
+    (react/useEffect
+     (fn mount []
+       (if onTick
+         ;; If I want to get fancy, this is everything that we should support
+         ;; https://github.com/unconed/mathbox/blob/master/src/primitives/types/time/clock.js
+
+         ;; TODO check if this is current for GCL?
+         (let [key (.-key
+                    (goog.events/listen
+                     t
+                     timer/TICK
+                     (fn []
+                       (onTick
+                        (/ (- (goog/now) now)
+                           1000)))))]
+           (fn []
+             (goog.events/unlistenByKey key)))
+         js/undefined))
+     #js [onTick])))
+
+(defn Stopwatch
+  "Wrapper around the function component [[Stopwatch*]]."
+  [opts]
+  [:f> Stopwatch* opts])


### PR DESCRIPTION
- #44:

  - Adds `emmy.viewer.physics` and `emmy.mathbox.physics` in support of the new
    `emmy.mathbox.physics/ode-curve` function, similar to `parametric-curve` but
    powered by a derivative function and initial state. See the new
    [ode](https://emmy-viewers.mentat.org/dev/examples/mathbox/ode) example page
    for a demo.

  - Adds a new Lorenz attractor example at `examples.mathbox.ode`.

  - Adds `emmy.clerk/{build!,serve!,halt!}` to make it more straightforward to
    configure Clerk with our custom JS bundle.

  - Adds a var-arg `viewers` argument for other viewers to
    `emmy.clerk/install!`.

  - Adds `emmy.viewer.stopwatch` with a client and server-side stopwatch
    component; this is currently alpha, but will be used for running physics
    animations.

  - Migrates `examples.simulation.toroid` to full server-side style with no more
    custom viewer.